### PR TITLE
Propose custom OSVersion type and PolicyManager.

### DIFF
--- a/Nudge.xcodeproj/project.pbxproj
+++ b/Nudge.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0B0CCEDA25CE1C7C00A93D43 /* OSVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B0CCED925CE1C7C00A93D43 /* OSVersion.swift */; };
+		0BC9972725CE26CE0019FC8F /* PolicyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BC9972625CE26CE0019FC8F /* PolicyManager.swift */; };
+		0BC9972C25CE2DFC0019FC8F /* OSVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BC9972B25CE2DFC0019FC8F /* OSVersionTests.swift */; };
 		639E194A25CC7F13008F618B /* example.json in Resources */ = {isa = PBXBuildFile; fileRef = 639E194925CC7F13008F618B /* example.json */; };
 		639E198225CD885D008F618B /* nudgePrefs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639E198125CD885D008F618B /* nudgePrefs.swift */; };
 		639E198A25CD9E21008F618B /* osUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639E198925CD9E21008F618B /* osUtils.swift */; };
@@ -37,6 +40,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0B0CCED925CE1C7C00A93D43 /* OSVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSVersion.swift; sourceTree = "<group>"; };
+		0BC9972625CE26CE0019FC8F /* PolicyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolicyManager.swift; sourceTree = "<group>"; };
+		0BC9972B25CE2DFC0019FC8F /* OSVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSVersionTests.swift; sourceTree = "<group>"; };
 		639E194925CC7F13008F618B /* example.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = example.json; sourceTree = "<group>"; };
 		639E198125CD885D008F618B /* nudgePrefs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = nudgePrefs.swift; sourceTree = "<group>"; };
 		639E198925CD9E21008F618B /* osUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = osUtils.swift; sourceTree = "<group>"; };
@@ -114,6 +120,8 @@
 				639E194925CC7F13008F618B /* example.json */,
 				639E198125CD885D008F618B /* nudgePrefs.swift */,
 				639E198925CD9E21008F618B /* osUtils.swift */,
+				0B0CCED925CE1C7C00A93D43 /* OSVersion.swift */,
+				0BC9972625CE26CE0019FC8F /* PolicyManager.swift */,
 			);
 			path = Nudge;
 			sourceTree = "<group>";
@@ -131,6 +139,7 @@
 			children = (
 				63D7D0F525C9E9A500236281 /* NudgeTests.swift */,
 				63D7D0F725C9E9A500236281 /* Info.plist */,
+				0BC9972B25CE2DFC0019FC8F /* OSVersionTests.swift */,
 			);
 			path = NudgeTests;
 			sourceTree = "<group>";
@@ -274,11 +283,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0B0CCEDA25CE1C7C00A93D43 /* OSVersion.swift in Sources */,
 				639E198A25CD9E21008F618B /* osUtils.swift in Sources */,
 				63D7D0E525C9E9A400236281 /* ContentView.swift in Sources */,
 				63D7D12725C9F1EE00236281 /* Nudge.swift in Sources */,
 				639E198225CD885D008F618B /* nudgePrefs.swift in Sources */,
 				63D7D0E325C9E9A400236281 /* NudgeApp.swift in Sources */,
+				0BC9972725CE26CE0019FC8F /* PolicyManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -286,6 +297,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0BC9972C25CE2DFC0019FC8F /* OSVersionTests.swift in Sources */,
 				63D7D0F625C9E9A500236281 /* NudgeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Nudge/ContentView.swift
+++ b/Nudge/ContentView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 // https://gist.github.com/steve228uk/c960b4880480c6ed186d
 
 struct ContentView: View {
+    @EnvironmentObject var manager: PolicyManager
     var body: some View {
         HostingWindowFinder {window in
             window?.standardWindowButton(.closeButton)?.isHidden = true //hides the red close button
@@ -26,7 +27,7 @@ struct ContentView: View {
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        ContentView()
+        ContentView().environmentObject(PolicyManager(withVersion:  try! OSVersion("11.1") ))
     }
 }
 

--- a/Nudge/Nudge.swift
+++ b/Nudge/Nudge.swift
@@ -37,6 +37,8 @@ struct Nudge: View {
     // Get the color scheme so we can dynamically change properties
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.openURL) var openURL
+    @EnvironmentObject var manager: PolicyManager
+
 
     // Get the screen frame
     var screen = NSScreen.main?.visibleFrame
@@ -110,7 +112,7 @@ struct Nudge: View {
                     HStack{
                         Text("Current OS Version: ")
                         Spacer()
-                        Text(String(current_os_version).capitalized)
+                        Text(manager.current.description)
                             .foregroundColor(.gray)
                     }.padding(.vertical, 1.0)
                     

--- a/Nudge/NudgeApp.swift
+++ b/Nudge/NudgeApp.swift
@@ -20,9 +20,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 @main
 struct NudgeApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    let manager = PolicyManager()
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView().environmentObject(manager)
         }
         // Hide Title Bar
         .windowStyle(HiddenTitleBarWindowStyle())

--- a/Nudge/OSVersion.swift
+++ b/Nudge/OSVersion.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+// Version of a macOS release. Example: 11.2
+public struct OSVersion {
+    public var major: Int
+    public var minor: Int
+    public var patch: Int
+    
+    public enum ParseError: Error {
+        case badFormat(_ reason: String)
+    }
+    
+    // Creates an OSVersion by providing all the parts.
+    public init(major: Int, minor: Int, patch: Int) {
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+    }
+    
+    // Creates an OSVersion by converting the built-in OperatingSystemVersion.
+    public init(_ version: OperatingSystemVersion) {
+        self.major = version.majorVersion
+        self.minor = version.minorVersion
+        self.patch = version.patchVersion
+    }
+    
+    // Creates an OSVersion by parsing a string like "11.2".
+    public init(_ string: String) throws {
+        let parts = string.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 2 || parts.count == 3 else {
+            throw ParseError.badFormat("Input \(string) must have either 2 or 3 parts, got \(parts.count).")
+        }
+        
+        guard
+            let major = Int(parts[0]),
+            let minor = Int(parts[1]),
+            let patch: Int = parts.count >= 3 ? Int(parts[2]) : 0 // optional, default to zero if missing.
+        else {
+            throw ParseError.badFormat("Converting string parts to Int")
+        }
+        self.init(major: major, minor: minor, patch: patch)
+    }
+}
+
+extension OSVersion: CustomStringConvertible {
+    public var description: String {
+        return "\(major).\(minor).\(patch)"
+    }
+}
+
+extension OSVersion: Equatable {
+    public static func == (lhs: OSVersion, rhs: OSVersion) -> Bool {
+        return (lhs.major, lhs.minor, lhs.patch) == (rhs.major, rhs.minor, rhs.patch)
+    }
+}
+
+extension OSVersion: Comparable {
+    public static func < (lhs: OSVersion, rhs: OSVersion) -> Bool {
+        return (lhs.major, lhs.minor, lhs.patch) < (rhs.major, rhs.minor, rhs.patch)
+    }
+}

--- a/Nudge/PolicyManager.swift
+++ b/Nudge/PolicyManager.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+// PolicyManager resolves the app state, separating the UI from external actions,
+// like interacting with the user, the OS or other parts of the environment.
+class PolicyManager: ObservableObject {
+    @Published var current: OSVersion
+    
+    init() {
+        self.current = OSVersion(ProcessInfo().operatingSystemVersion)
+    }
+    
+    init(withVersion: OSVersion) {
+        self.current = withVersion
+    }
+}

--- a/NudgeTests/OSVersionTests.swift
+++ b/NudgeTests/OSVersionTests.swift
@@ -1,0 +1,37 @@
+//
+//  OSVersionTests.swift
+//  NudgeTests
+//
+//  Created by groob on 2/5/21.
+//
+
+import Foundation
+import XCTest
+@testable import Nudge
+
+
+class OSVersionTest: XCTestCase {
+    func testCompare() {
+        let a = OSVersion(major: 11, minor: 2, patch: 0)
+        let b = OSVersion(major: 11, minor: 2, patch: 0)
+        let c = OSVersion(major: 11, minor: 3, patch: 0)
+        let d = OSVersion(major: 10, minor: 15, patch: 9999)
+
+        
+        XCTAssertEqual(a,b)
+        XCTAssertNotEqual(a,c)
+        XCTAssertGreaterThan(c,b)
+        XCTAssertGreaterThanOrEqual(c,d)
+        XCTAssertFalse(a < d, "BigSur is newer than Catalina")
+    }
+    
+    func testParse() {
+        let expected = OSVersion(major: 11, minor: 5, patch: 0)
+        guard let actual = try? OSVersion("11.5") else {
+            XCTFail("expected OSVersion to not fail parsing '11.5'")
+            return
+        }
+        
+        XCTAssertEqual(expected, actual)
+    }
+}


### PR DESCRIPTION
First, a new OSVersion type, specific for Nudge.
It can be initialized from both the OperatingSystemVersion type Apple provides
or by parsing a string. Having a custom type has several benefits and guarantees.
For example, configuration values (usually strings) will be parsed consistently.
The type has additonal extensions making it comparable,
equatable and convertible to a custom string.

My second change is a bit more ambitious, so I left the implementation
minimal, with the intention to grow it if accepted.
I created a "PolicyManager" class (naming things is hard), passed
to the ContentView as an EnvironmentObject. The policy manager is intended to
separate the UI from all the actions Nudge would take, like loading
preferences, getting the OS version, launching System Preferences and so
on. I'd like to refactor all the standalone helpers/global values into
this class and give it more structure.