### PR TITLE
Simple Mode and a brand new UI

### DIFF
--- a/Nudge/Nudge.swift
+++ b/Nudge/Nudge.swift
@@ -36,8 +36,7 @@ struct Nudge: View {
 
     // Nudge UI
     var body: some View {
-        HStack(spacing: 0){
-            // Left side of Nudge
+        if simpleMode {
             VStack{
                 // Company Logo
                 if colorScheme == .dark {
@@ -46,13 +45,14 @@ struct Nudge: View {
                             .resizable()
                             .aspectRatio(contentMode: .fit)
                             .scaledToFit()
-                            .frame(width: 200, height: 150)
+                            .frame(width: 300, height: 225)
                     } else {
                         Image(systemName: "applelogo")
                             .resizable()
                             .aspectRatio(contentMode: .fit)
                             .scaledToFit()
                             .frame(width: 200, height: 150)
+                            .padding(.vertical, 50)
                     }
                 } else {
                     if FileManager.default.fileExists(atPath: iconLightPath) {
@@ -60,293 +60,392 @@ struct Nudge: View {
                             .resizable()
                             .aspectRatio(contentMode: .fit)
                             .scaledToFit()
-                            .frame(width: 200, height: 150)
+                            .frame(width: 300, height: 225)
+                            .padding(.vertical, 2)
                     } else {
                         Image(systemName: "applelogo")
                             .resizable()
                             .aspectRatio(contentMode: .fit)
                             .scaledToFit()
                             .frame(width: 200, height: 150)
+                            .padding(.vertical, 50)
                     }
                 }
 
-                // Horizontal line
-                HStack{
-                    Rectangle()
-                        .fill(Color.gray.opacity(0.5))
-                        .frame(height: 1)
+                // mainContent Header
+                HStack {
+                    Text(mainContentHeader)
+                        .font(.title)
+                        .fontWeight(.bold)
                 }
-                .frame(width: 300)
+                .padding(.vertical, 2)
+
+                // Days Remaining
+                HStack {
+                    Text("Days remaining to update:")
+                        .font(.title2)
+                    if self.daysRemaining <= 0 {
+                        Text(String(0))
+                            .font(.title2)
+                            .fontWeight(.bold)
+                    } else {
+                        Text(String(self.daysRemaining))
+                            .font(.title2)
+                            .fontWeight(.bold)
+                    }
+                }
+                .padding(.vertical, 2)
                 
-                // Can only have 10 objects per stack unless you hack it and use groups
-                Group {
-                    // Required OS Version
-                    HStack{
-                        Text("Required OS Version: ")
-                            .fontWeight(.bold)
-                        Spacer()
-                        Text(String(requiredMinimumOSVersion).capitalized)
-                            .foregroundColor(.secondary)
-                            .fontWeight(.bold)
-                    }
-                    .padding(.vertical, 1)
-                    
-                    // Current OS Version
-                    HStack{
-                        Text("Current OS Version: ")
-                        Spacer()
-                        Text(manager.current.description)
-                            .foregroundColor(.secondary)
-                    }
-                    .padding(.vertical, 1)
-                    
-                    // Username
-                    HStack{
-                        Text("Username: ")
-                        Spacer()
-                        Text(self.systemConsoleUsername)
-                            .foregroundColor(.secondary)
-                    }
-                    .padding(.vertical, 1)
+                // Update Device button
+                Button(action: Utils().updateDevice, label: {
+                    Text("Update Device")
+                        .frame(minWidth: 100)
+                  }
+                )
+                .keyboardShortcut(.defaultAction)
+                .padding(.vertical, 2)
 
-                    // Serial Number
-                    HStack{
-                        Text("Serial Number: ")
-                        Spacer()
-                        Text(self.serialNumber)
-                            .foregroundColor(.secondary)
+                // OK button
+                Button(action: {AppKit.NSApp.terminate(nil)}, label: {
+                    Text("OK")
+                        .frame(minWidth: 100)
                     }
-                    .padding(.vertical, 1)
-
-                    // Architecture
-                    HStack{
-                        Text("Architecture: ")
-                        Spacer()
-                        Text(self.cpuType)
-                            .foregroundColor(.secondary)
-                    }
-                    .padding(.vertical, 1)
-
-                    // Days Remaining
-                    HStack{
-                        Text("Days Remaining: ")
-                        Spacer()
-                        if self.daysRemaining <= 0 {
-                            Text(String(0))
-                                .foregroundColor(.secondary)
-                        } else {
-                            Text(String(self.daysRemaining))
-                                .foregroundColor(.secondary)
-                        }
-                    }
-                    .padding(.vertical, 1)
-
-                    // Deferral Count
-                    HStack{
-                        Text("Deferral Count: ")
-                        Spacer()
-                        Text(String(self.deferralCountUI))
-                            .onReceive(nudgeRefreshCycleTimer) { _ in
-                                if needToActivateNudge(deferralCountVar: deferralCount, lastRefreshTimeVar: lastRefreshTime) {
-                                    self.deferralCountUI += 1
-                                }
-                            }
-                            .foregroundColor(.secondary)
-                    }
-                }
-                .padding(.leading, 20)
-                .padding(.trailing, 10)
-
-                // Force buttons to the bottom with a spacer
-                Spacer()
-
+                )
+                .padding(.vertical, 2)
+                
                 // More Info
                 // https://developer.apple.com/documentation/swiftui/openurlaction
-                HStack(alignment: .top) {
+                HStack {
+                    // Force the button to the right with a spacer
+                    Spacer()
                     if informationButtonPath != "" {
                         Button(action: Utils().openMoreInfo, label: {
                             Text("More Info")
                           }
                         )
+                        .buttonStyle(BorderlessButtonStyle())
+                        .padding(.trailing, 20)
                     }
-                    // Force the button to the left with a spacer
-                    Spacer()
                 }
-                .padding(.leading, 20)
-                .padding(.bottom, 52.5)
+                // https://www.hackingwithswift.com/books/ios-swiftui/running-code-when-our-app-launches
+                .onAppear(perform: nudgeStartLogic)
             }
-            .frame(width: 300, height: 525)
-            
-            // Vertical Line
-            VStack{
-                Rectangle()
-                    .fill(Color.gray.opacity(0.5))
-                    .frame(width: 1)
-            }
-            .frame(height: 525)
-
-            // Right side of Nudge
-            VStack{
-                // mainHeader Text
-                HStack {
-                    Text(mainHeader)
-                        .font(.largeTitle)
-                }
-                .frame(width: 550)
-
-                // subHeader Text
-                HStack {
-                    Text(subHeader)
-                        .font(.body)
-                }
-                .padding(.vertical, 0.5)
-                .frame(width: 550)
-
-                // mainContent Header
-                HStack {
-                    Text(mainContentHeader)
-                        .font(.body)
-                        .fontWeight(.bold)
-                }
-                .padding(.vertical, 0.5)
-                .frame(width: 550)
-
-                VStack(alignment: .leading) {
-                    // mainContent Text
-                    Text(mainContentText)
-                        .font(.body)
-                        .fontWeight(.regular)
-                        .multilineTextAlignment(.leading)
-                        //.frame(maxWidth: .infinity, alignment: .leading)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .padding(.vertical, 0.5)
-
-                // Company Screenshot
-                    HStack {
-                        Spacer()
-                        Group{
-                            if colorScheme == .dark && FileManager.default.fileExists(atPath: screenShotDarkPath) {
-                                Image(nsImage: Utils().createImageData(fileImagePath: screenShotDarkPath))
-                                    .resizable().scaledToFit()
-                                    .aspectRatio(contentMode: .fit)
-                            } else if colorScheme == .light && FileManager.default.fileExists(atPath: screenShotLightPath) {
-                                Image(nsImage: Utils().createImageData(fileImagePath: screenShotLightPath))
-                                    .resizable().scaledToFit()
-                                    .aspectRatio(contentMode: .fit)
-                            } else {
-                                Image("CompanyScreenshotIcon")
-                                    .resizable().scaledToFit()
-                                    .aspectRatio(contentMode: .fit)
-                            }
-                            Button(action: {
-                                self.showSSDetail.toggle()
-                            }) {
-                                Image(systemName: "plus.magnifyingglass")
-                            }
-                            .padding(.leading, -15)
-                            .sheet(isPresented: $showSSDetail) {
-                                screenShotZoom()
-                            }
-                            .help("Click to zoom into screenshot")
+            .frame(width: 900, height: 450)
+        } else {
+            HStack(spacing: 0){
+                // Left side of Nudge
+                VStack{
+                    // Company Logo
+                    if colorScheme == .dark {
+                        if FileManager.default.fileExists(atPath: iconDarkPath) {
+                            Image(nsImage: Utils().createImageData(fileImagePath: iconDarkPath))
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .scaledToFit()
+                                .frame(width: 200, height: 150)
+                        } else {
+                            Image(systemName: "applelogo")
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .scaledToFit()
+                                .frame(width: 200, height: 150)
                         }
+                    } else {
+                        if FileManager.default.fileExists(atPath: iconLightPath) {
+                            Image(nsImage: Utils().createImageData(fileImagePath: iconLightPath))
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .scaledToFit()
+                                .frame(width: 200, height: 150)
+                        } else {
+                            Image(systemName: "applelogo")
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .scaledToFit()
+                                .frame(width: 200, height: 150)
+                        }
+                    }
+
+                    // Horizontal line
+                    HStack{
+                        Rectangle()
+                            .fill(Color.gray.opacity(0.5))
+                            .frame(height: 1)
+                    }
+                    .frame(width: 300)
+                    
+                    // Can only have 10 objects per stack unless you hack it and use groups
+                    Group {
+                        // Required OS Version
+                        HStack{
+                            Text("Required OS Version: ")
+                                .fontWeight(.bold)
+                            Spacer()
+                            Text(String(requiredMinimumOSVersion).capitalized)
+                                .foregroundColor(.secondary)
+                                .fontWeight(.bold)
+                        }
+                        .padding(.vertical, 1)
+                        
+                        // Current OS Version
+                        HStack{
+                            Text("Current OS Version: ")
+                            Spacer()
+                            Text(manager.current.description)
+                                .foregroundColor(.secondary)
+                        }
+                        .padding(.vertical, 1)
+                        
+                        // Username
+                        HStack{
+                            Text("Username: ")
+                            Spacer()
+                            Text(self.systemConsoleUsername)
+                                .foregroundColor(.secondary)
+                        }
+                        .padding(.vertical, 1)
+
+                        // Serial Number
+                        HStack{
+                            Text("Serial Number: ")
+                            Spacer()
+                            Text(self.serialNumber)
+                                .foregroundColor(.secondary)
+                        }
+                        .padding(.vertical, 1)
+
+                        // Architecture
+                        HStack{
+                            Text("Architecture: ")
+                            Spacer()
+                            Text(self.cpuType)
+                                .foregroundColor(.secondary)
+                        }
+                        .padding(.vertical, 1)
+
+                        // Days Remaining
+                        HStack{
+                            Text("Days Remaining: ")
+                            Spacer()
+                            if self.daysRemaining <= 0 {
+                                Text(String(0))
+                                    .foregroundColor(.secondary)
+                            } else {
+                                Text(String(self.daysRemaining))
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                        .padding(.vertical, 1)
+
+                        // Deferral Count
+                        HStack{
+                            Text("Deferral Count: ")
+                            Spacer()
+                            Text(String(self.deferralCountUI))
+                                .onReceive(nudgeRefreshCycleTimer) { _ in
+                                    if needToActivateNudge(deferralCountVar: deferralCount, lastRefreshTimeVar: lastRefreshTime) {
+                                        self.deferralCountUI += 1
+                                    }
+                                }
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    .padding(.leading, 20)
+                    .padding(.trailing, 10)
+
+                    // Force buttons to the bottom with a spacer
+                    Spacer()
+
+                    // More Info
+                    // https://developer.apple.com/documentation/swiftui/openurlaction
+                    HStack(alignment: .top) {
+                        if informationButtonPath != "" {
+                            Button(action: Utils().openMoreInfo, label: {
+                                Text("More Info")
+                              }
+                            )
+                            .buttonStyle(BorderlessButtonStyle())
+                        }
+                        // Force the button to the left with a spacer
                         Spacer()
                     }
+                    .padding(.leading, 20)
+                    .padding(.bottom, 55)
                 }
-                .padding(.vertical, 0.5)
-                .frame(width: 550)
-
-                // Force buttons to the bottom with a spacer
-                Spacer()
+                .frame(width: 300, height: 525)
                 
-                // lowerHeader
-                VStack(alignment: .leading) {
-                    // lowerHeader Text
+                // Vertical Line
+                VStack{
+                    Rectangle()
+                        .fill(Color.gray.opacity(0.5))
+                        .frame(width: 1)
+                }
+                .frame(height: 525)
+
+                // Right side of Nudge
+                VStack{
+                    // mainHeader Text
                     HStack {
-                        Text(lowerHeader)
+                        Text(mainHeader)
+                            .font(.largeTitle)
+                    }
+                    .frame(width: 550)
+
+                    // subHeader Text
+                    HStack {
+                        Text(subHeader)
+                            .font(.body)
+                    }
+                    .padding(.vertical, 0.5)
+                    .frame(width: 550)
+
+                    // mainContent Header
+                    HStack {
+                        Text(mainContentHeader)
                             .font(.body)
                             .fontWeight(.bold)
-                        Spacer()
                     }
-                    HStack {
-                        // lowerSubHeader Text
-                        Text(lowerSubHeader)
-                            .font(.body)
-                        Spacer()
-                    }
-                }
-                .frame(width: 550)
+                    .padding(.vertical, 0.5)
+                    .frame(width: 550)
 
-                // Bottom buttons
-                HStack {
-                    // Update Device button
-                    Button(action: Utils().updateDevice, label: {
-                        Text("Update Device")
-                      }
-                    )
-                    
-                    // Separate the buttons with a spacer
+                    VStack(alignment: .leading) {
+                        // mainContent Text
+                        Text(mainContentText)
+                            .font(.body)
+                            .fontWeight(.regular)
+                            .multilineTextAlignment(.leading)
+                            //.frame(maxWidth: .infinity, alignment: .leading)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(.vertical, 0.5)
+
+                    // Company Screenshot
+                        HStack {
+                            Spacer()
+                            Group{
+                                if colorScheme == .dark && FileManager.default.fileExists(atPath: screenShotDarkPath) {
+                                    Image(nsImage: Utils().createImageData(fileImagePath: screenShotDarkPath))
+                                        .resizable().scaledToFit()
+                                        .aspectRatio(contentMode: .fit)
+                                } else if colorScheme == .light && FileManager.default.fileExists(atPath: screenShotLightPath) {
+                                    Image(nsImage: Utils().createImageData(fileImagePath: screenShotLightPath))
+                                        .resizable().scaledToFit()
+                                        .aspectRatio(contentMode: .fit)
+                                } else {
+                                    Image("CompanyScreenshotIcon")
+                                        .resizable().scaledToFit()
+                                        .aspectRatio(contentMode: .fit)
+                                }
+                                Button(action: {
+                                    self.showSSDetail.toggle()
+                                }) {
+                                    Image(systemName: "plus.magnifyingglass")
+                                }
+                                .padding(.leading, -15)
+                                .sheet(isPresented: $showSSDetail) {
+                                    screenShotZoom()
+                                }
+                                .help("Click to zoom into screenshot")
+                            }
+                            Spacer()
+                        }
+                    }
+                    .padding(.vertical, 0.5)
+                    .frame(width: 550)
+
+                    // Force buttons to the bottom with a spacer
                     Spacer()
                     
-                    if Utils().demoModeEnabled() || !pastRequiredInstallationDate && allowedDeferrals > self.deferralCountUI {
-                        // I understand button
-                        if requireDualCloseButtons {
-                            if self.hasAcceptedIUnderstand {
+                    // lowerHeader
+                    VStack(alignment: .leading) {
+                        // lowerHeader Text
+                        HStack {
+                            Text(lowerHeader)
+                                .font(.body)
+                                .fontWeight(.bold)
+                            Spacer()
+                        }
+                        HStack {
+                            // lowerSubHeader Text
+                            Text(lowerSubHeader)
+                                .font(.body)
+                            Spacer()
+                        }
+                    }
+                    .frame(width: 550)
+
+                    // Bottom buttons
+                    HStack {
+                        // Update Device button
+                        Button(action: Utils().updateDevice, label: {
+                            Text("Update Device")
+                          }
+                        )
+                        .keyboardShortcut(.defaultAction)
+                        
+                        // Separate the buttons with a spacer
+                        Spacer()
+                        
+                        if Utils().demoModeEnabled() || !pastRequiredInstallationDate && allowedDeferrals > self.deferralCountUI {
+                            // I understand button
+                            if requireDualCloseButtons {
+                                if self.hasAcceptedIUnderstand {
+                                    Button(action: {}, label: {
+                                        Text("I understand")
+                                      }
+                                    )
+                                    .hidden()
+                                } else {
+                                    Button(action: {
+                                        hasAcceptedIUnderstand = true
+                                    }, label: {
+                                        Text("I understand")
+                                      }
+                                    )
+                                }
+                            } else {
                                 Button(action: {}, label: {
                                     Text("I understand")
                                   }
                                 )
                                 .hidden()
-                            } else {
-                                Button(action: {
-                                    hasAcceptedIUnderstand = true
-                                }, label: {
-                                    Text("I understand")
-                                  }
-                                )
                             }
-                        } else {
-                            Button(action: {}, label: {
-                                Text("I understand")
-                              }
-                            )
-                            .hidden()
-                        }
-                    
-                        // OK button
-                        if requireDualCloseButtons {
-                            if self.hasAcceptedIUnderstand {
+                        
+                            // OK button
+                            if requireDualCloseButtons {
+                                if self.hasAcceptedIUnderstand {
+                                    Button(action: {AppKit.NSApp.terminate(nil)}, label: {
+                                        Text("OK")
+                                            .frame(minWidth: 35)
+                                      }
+                                    )
+                                } else {
+                                    Button(action: {
+                                        hasAcceptedIUnderstand = true
+                                    }, label: {
+                                        Text("OK")
+                                            .frame(minWidth: 35)
+                                      }
+                                    )
+                                    .hidden()
+                                }
+                            } else {
                                 Button(action: {AppKit.NSApp.terminate(nil)}, label: {
                                     Text("OK")
                                         .frame(minWidth: 35)
                                   }
                                 )
-                            } else {
-                                Button(action: {
-                                    hasAcceptedIUnderstand = true
-                                }, label: {
-                                    Text("OK")
-                                        .frame(minWidth: 35)
-                                  }
-                                )
-                                .hidden()
                             }
-                        } else {
-                            Button(action: {AppKit.NSApp.terminate(nil)}, label: {
-                                Text("OK")
-                                    .frame(minWidth: 35)
-                              }
-                            )
                         }
                     }
+                    .frame(width: 550)
                 }
-                .frame(width: 550)
+                .frame(width: 600)
+                .padding(.bottom, 15)
+                // https://www.hackingwithswift.com/books/ios-swiftui/running-code-when-our-app-launches
+                .onAppear(perform: nudgeStartLogic)
             }
-            .frame(width: 600)
-            .padding(.bottom, 15)
-            // https://www.hackingwithswift.com/books/ios-swiftui/running-code-when-our-app-launches
-            .onAppear(perform: nudgeStartLogic)
+            .frame(width: 900, height: 450)
         }
-        .frame(width: 900, height: 450)
     }
 }
 

--- a/Nudge/Nudge.swift
+++ b/Nudge/Nudge.swift
@@ -286,7 +286,7 @@ struct Nudge: View {
                 VStack{
                     // mainHeader Text
                     HStack {
-                        Text(mainHeader)
+                        Text(getMainHeader())
                             .font(.largeTitle)
                     }
                     .frame(width: 550)

--- a/Nudge/Nudge.swift
+++ b/Nudge/Nudge.swift
@@ -25,8 +25,9 @@ struct Nudge: View {
     @State var hasClickedSecondaryQuitButton = false
     @State var deferralCountUI = 0
     
-    // Modal view for screenshot
+    // Modal view for screenshot and device info
     @State var showSSDetail = false
+    @State var showDeviceInfo = false
     
     // Get the screen frame
     var screen = NSScreen.main?.visibleFrame
@@ -72,9 +73,9 @@ struct Nudge: View {
                     }
                 }
 
-                // mainContent Header
+                // mainHeader
                 HStack {
-                    Text(mainContentHeader)
+                    Text(getMainHeader())
                         .font(.title)
                         .fontWeight(.bold)
                 }
@@ -119,9 +120,10 @@ struct Nudge: View {
                     // Force the button to the right with a spacer
                     Spacer()
                     // informationButton
-                    if informationButtonPath != "" {
+                    if aboutUpdateURL != "" {
                         Button(action: Utils().openMoreInfo, label: {
                             Text(informationButtonText)
+                                .foregroundColor(.secondary)
                           }
                         )
                         .buttonStyle(BorderlessButtonStyle())
@@ -135,7 +137,21 @@ struct Nudge: View {
         } else {
             HStack(spacing: 0){
                 // Left side of Nudge
+                // Additional Device Information
                 VStack{
+                    Button(action: {
+                        self.showDeviceInfo.toggle()
+                    }) {
+                        Image(systemName: "questionmark.circle")
+                    }
+                    .padding(.leading, -140)
+                    .padding(.top, -25.0)
+                    .buttonStyle(BorderlessButtonStyle())
+                    .sheet(isPresented: $showDeviceInfo) {
+                        deviceInfo()
+                    }
+                    .help("Click for additional device information")
+
                     // Company Logo
                     if colorScheme == .dark {
                         if FileManager.default.fileExists(atPath: iconDarkPath) {
@@ -173,7 +189,10 @@ struct Nudge: View {
                             .fill(Color.gray.opacity(0.5))
                             .frame(height: 1)
                     }
-                    .frame(width: 300)
+                    .padding(.top, 20)
+                    .padding(.bottom, 20)
+                    .frame(width: 230)
+                    
                     
                     // Can only have 10 objects per stack unless you hack it and use groups
                     Group {
@@ -182,11 +201,10 @@ struct Nudge: View {
                             Text("Required OS Version: ")
                                 .fontWeight(.bold)
                             Spacer()
-                            Text(String(requiredMinimumOSVersion).capitalized)
+                            Text(String(requiredMinimumOSVersion))
                                 .foregroundColor(.secondary)
                                 .fontWeight(.bold)
                         }
-                        .padding(.vertical, 1)
                         
                         // Current OS Version
                         HStack{
@@ -195,34 +213,6 @@ struct Nudge: View {
                             Text(manager.current.description)
                                 .foregroundColor(.secondary)
                         }
-                        .padding(.vertical, 1)
-                        
-                        // Username
-                        HStack{
-                            Text("Username: ")
-                            Spacer()
-                            Text(self.systemConsoleUsername)
-                                .foregroundColor(.secondary)
-                        }
-                        .padding(.vertical, 1)
-
-                        // Serial Number
-                        HStack{
-                            Text("Serial Number: ")
-                            Spacer()
-                            Text(self.serialNumber)
-                                .foregroundColor(.secondary)
-                        }
-                        .padding(.vertical, 1)
-
-                        // Architecture
-                        HStack{
-                            Text("Architecture: ")
-                            Spacer()
-                            Text(self.cpuType)
-                                .foregroundColor(.secondary)
-                        }
-                        .padding(.vertical, 1)
 
                         // Days Remaining
                         HStack{
@@ -236,7 +226,6 @@ struct Nudge: View {
                                     .foregroundColor(.secondary)
                             }
                         }
-                        .padding(.vertical, 1)
 
                         // Deferral Count
                         HStack{
@@ -251,8 +240,8 @@ struct Nudge: View {
                                 .foregroundColor(.secondary)
                         }
                     }
-                    .padding(.leading, 20)
-                    .padding(.trailing, 10)
+                    .frame(width: 250)
+                    .padding(.vertical, 0.5)
 
                     // Force buttons to the bottom with a spacer
                     Spacer()
@@ -261,20 +250,22 @@ struct Nudge: View {
                     // https://developer.apple.com/documentation/swiftui/openurlaction
                     HStack(alignment: .top) {
                         // informationButton
-                        if informationButtonPath != "" {
+                        if aboutUpdateURL != "" {
                             Button(action: Utils().openMoreInfo, label: {
                                 Text(informationButtonText)
+                                    .foregroundColor(.secondary)
                               }
                             )
                             .buttonStyle(BorderlessButtonStyle())
+                            
                         }
                         // Force the button to the left with a spacer
                         Spacer()
                     }
-                    .padding(.leading, 20)
-                    .padding(.bottom, 55)
+                    .frame(width: 250)
+                    .padding(.bottom, 17.5)
                 }
-                .frame(width: 300, height: 525)
+                .frame(width: 300, height: 450)
                 
                 // Vertical Line
                 VStack{
@@ -286,159 +277,183 @@ struct Nudge: View {
 
                 // Right side of Nudge
                 VStack{
-                    // mainHeader Text
-                    HStack {
-                        Text(getMainHeader())
-                            .font(.largeTitle)
-                    }
-                    .frame(width: 550)
-
-                    // subHeader Text
-                    HStack {
-                        Text(subHeader)
-                            .font(.body)
-                    }
-                    .padding(.vertical, 0.5)
-                    .frame(width: 550)
-
-                    // mainContent Header
-                    HStack {
-                        Text(mainContentHeader)
-                            .font(.body)
-                            .fontWeight(.bold)
-                    }
-                    .padding(.vertical, 0.5)
-                    .frame(width: 550)
-
-                    VStack(alignment: .leading) {
-                        // mainContent Text
-                        Text(mainContentText)
-                            .font(.body)
-                            .fontWeight(.regular)
-                            .multilineTextAlignment(.leading)
-                            //.frame(maxWidth: .infinity, alignment: .leading)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .padding(.vertical, 0.5)
-
-                    // Company Screenshot
+                    Group {
+                        // mainHeader
                         HStack {
-                            Spacer()
-                            Group{
-                                if colorScheme == .dark && FileManager.default.fileExists(atPath: screenShotDarkPath) {
-                                    Image(nsImage: Utils().createImageData(fileImagePath: screenShotDarkPath))
-                                        .resizable().scaledToFit()
-                                        .aspectRatio(contentMode: .fit)
-                                } else if colorScheme == .light && FileManager.default.fileExists(atPath: screenShotLightPath) {
-                                    Image(nsImage: Utils().createImageData(fileImagePath: screenShotLightPath))
-                                        .resizable().scaledToFit()
-                                        .aspectRatio(contentMode: .fit)
-                                } else {
-                                    Image("CompanyScreenshotIcon")
-                                        .resizable().scaledToFit()
-                                        .aspectRatio(contentMode: .fit)
-                                }
-                                Button(action: {
-                                    self.showSSDetail.toggle()
-                                }) {
-                                    Image(systemName: "plus.magnifyingglass")
-                                }
-                                .padding(.leading, -15)
-                                .sheet(isPresented: $showSSDetail) {
-                                    screenShotZoom()
-                                }
-                                .help("Click to zoom into screenshot")
-                            }
+                            Text(getMainHeader())
+                                .font(.largeTitle)
+                                .multilineTextAlignment(.leading)
+                                .minimumScaleFactor(0.5)
+                                .lineLimit(1)
                             Spacer()
                         }
-                    }
-                    .padding(.vertical, 0.5)
-                    .frame(width: 550)
-
-                    // Force buttons to the bottom with a spacer
-                    Spacer()
-                    
-                    // lowerHeader
-                    VStack(alignment: .leading) {
-                        // lowerHeader Text
+                        // subHeader
                         HStack {
-                            Text(lowerHeader)
+                            Text(subHeader)
                                 .font(.body)
                                 .fontWeight(.bold)
                             Spacer()
                         }
-                        HStack {
-                            // lowerSubHeader Text
-                            Text(lowerSubHeader)
-                                .font(.body)
-                            Spacer()
-                        }
                     }
-                    .frame(width: 550)
+                    .padding(.vertical, 0.5)
+                    .frame(width: 500)
+                    
+                    // I'm kind of impressed with myself
+                    Group {
+                        VStack(alignment: .leading) {
+                            // mainContentHeader / mainContentSubHeader
+                            HStack {
+                                Group {
+                                    VStack {
+                                        HStack {
+                                            Text(mainContentHeader)
+                                                .font(.callout)
+                                                .fontWeight(.bold)
+                                            Spacer()
+                                        }
+                                        HStack {
+                                            Text(mainContentSubHeader)
+                                                .font(.callout)
+                                            Spacer()
+                                        }
+                                    }
+                                }
+                                Spacer()
+                                // actionButton
+                                Button(action: Utils().updateDevice, label: {
+                                    Text(actionButtonText)
+                                  }
+                                )
+                                .keyboardShortcut(.defaultAction)
+                            }
+                            .padding(.top, 20.0)
+                            .padding(.leading, 20.0)
+                            .padding(.trailing, 20.0)
+                            
+                            // Horizontal line
+                            HStack{
+                                Rectangle()
+                                    .fill(Color.gray.opacity(0.5))
+                                    .frame(height: 1)
+                            }
+                            .padding(.leading, 20.0)
+                            .padding(.top, 10)
+                            .padding(.bottom, 10)
+                            .frame(width: 525)
+                            
+                            // mainContentNote
+                            HStack {
+                                Text(mainContentNote)
+                                    .font(.callout)
+                                    .fontWeight(.bold)
+                                    .foregroundColor(Color.red)
+                                Spacer()
+                            }
+                            .padding(.leading, 20.0)
+                            
+                            // mainContentText
+                            Text(mainContentText)
+                                .font(.callout)
+                                .font(.body)
+                                .fontWeight(.regular)
+                                .multilineTextAlignment(.leading)
+                                //.frame(maxWidth: .infinity, alignment: .leading)
+                                .fixedSize(horizontal: false, vertical: true)
+                                .padding(.leading, 20.0)
 
-                    // Bottom buttons
-                    HStack {
-                        // actionButton
-                        Button(action: Utils().updateDevice, label: {
-                            Text(actionButtonText)
-                          }
-                        )
-                        .keyboardShortcut(.defaultAction)
-                        
-                        // Separate the buttons with a spacer
-                        Spacer()
-                        
-                        if Utils().demoModeEnabled() || !pastRequiredInstallationDate && allowedDeferrals > self.deferralCountUI {
-                            // secondaryQuitButton
-                            if requireDualQuitButtons {
-                                if self.hasClickedSecondaryQuitButton {
+                        // Company Screenshot
+                            HStack {
+                                Spacer()
+                                Group{
+                                    if colorScheme == .dark && FileManager.default.fileExists(atPath: screenShotDarkPath) {
+                                        Image(nsImage: Utils().createImageData(fileImagePath: screenShotDarkPath))
+                                            .resizable().scaledToFit()
+                                            .aspectRatio(contentMode: .fit)
+                                    } else if colorScheme == .light && FileManager.default.fileExists(atPath: screenShotLightPath) {
+                                        Image(nsImage: Utils().createImageData(fileImagePath: screenShotLightPath))
+                                            .resizable().scaledToFit()
+                                            .aspectRatio(contentMode: .fit)
+                                    } else {
+                                        Image("CompanyScreenshotIcon")
+                                            .resizable().scaledToFit()
+                                            .aspectRatio(contentMode: .fit)
+                                    }
+                                    Button(action: {
+                                        self.showSSDetail.toggle()
+                                    }) {
+                                        Image(systemName: "plus.magnifyingglass")
+                                    }
+                                    .padding(.leading, -10)
+                                    .sheet(isPresented: $showSSDetail) {
+                                        screenShotZoom()
+                                    }
+                                    .help("Click to zoom into screenshot")
+                                }
+                                Spacer()
+                            }
+                        }
+                        .background(Color.secondary.opacity(0.1))
+                        .cornerRadius(5)
+
+                        // Bottom buttons
+                        HStack {
+                            // Separate the buttons with a spacer
+                            Spacer()
+                            
+                            if Utils().demoModeEnabled() || !pastRequiredInstallationDate && allowedDeferrals > self.deferralCountUI {
+                                // secondaryQuitButton
+                                if requireDualQuitButtons {
+                                    if self.hasClickedSecondaryQuitButton {
+                                        Button(action: {}, label: {
+                                            Text(secondaryQuitButtonText)
+                                          }
+                                        )
+                                        .hidden()
+                                    } else {
+                                        Button(action: {
+                                            hasClickedSecondaryQuitButton = true
+                                        }, label: {
+                                            Text(secondaryQuitButtonText)
+                                          }
+                                        )
+                                    }
+                                } else {
                                     Button(action: {}, label: {
                                         Text(secondaryQuitButtonText)
                                       }
                                     )
                                     .hidden()
-                                } else {
-                                    Button(action: {
-                                        hasClickedSecondaryQuitButton = true
-                                    }, label: {
-                                        Text(secondaryQuitButtonText)
-                                      }
-                                    )
                                 }
-                            } else {
-                                Button(action: {}, label: {
-                                    Text(secondaryQuitButtonText)
-                                  }
-                                )
-                                .hidden()
-                            }
-                        
-                            // primaryQuitButton
-                            if requireDualQuitButtons {
-                                if self.hasClickedSecondaryQuitButton {
+                            
+                                // primaryQuitButton
+                                if requireDualQuitButtons {
+                                    if self.hasClickedSecondaryQuitButton {
+                                        Button(action: {AppKit.NSApp.terminate(nil)}, label: {
+                                            Text(primaryQuitButtonText)
+                                                .frame(minWidth: 35)
+                                          }
+                                        )
+                                    } else {
+                                        Button(action: {
+                                            hasClickedSecondaryQuitButton = true
+                                        }, label: {
+                                            Text(primaryQuitButtonText)
+                                                .frame(minWidth: 35)
+                                          }
+                                        )
+                                        .hidden()
+                                    }
+                                } else {
                                     Button(action: {AppKit.NSApp.terminate(nil)}, label: {
                                         Text(primaryQuitButtonText)
                                             .frame(minWidth: 35)
                                       }
                                     )
-                                } else {
-                                    Button(action: {
-                                        hasClickedSecondaryQuitButton = true
-                                    }, label: {
-                                        Text(primaryQuitButtonText)
-                                            .frame(minWidth: 35)
-                                      }
-                                    )
-                                    .hidden()
                                 }
-                            } else {
-                                Button(action: {AppKit.NSApp.terminate(nil)}, label: {
-                                    Text(primaryQuitButtonText)
-                                        .frame(minWidth: 35)
-                                  }
-                                )
                             }
                         }
                     }
+                    .padding(.vertical, 0.5)
                     .frame(width: 550)
                 }
                 .frame(width: 600)
@@ -479,6 +494,73 @@ struct screenShotZoom: View {
         )
         .buttonStyle(PlainButtonStyle())
         .help("Click to close")
+    }
+}
+
+
+// Sheet view for Device Information
+struct deviceInfo: View {
+    @Environment(\.presentationMode) var presentationMode
+    @Environment(\.colorScheme) var colorScheme
+    
+    // State variables
+    @State var systemConsoleUsername = Utils().getSystemConsoleUsername()
+    @State var serialNumber = Utils().getSerialNumber()
+    @State var cpuType = Utils().getCPUTypeString()
+    
+    var body: some View {
+        VStack {
+            HStack {
+                Button(
+                    action: {
+                        self.presentationMode.wrappedValue.dismiss()})
+                {
+                    Image(systemName: "xmark.circle")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .scaledToFit()
+                        .frame(width: 20, height: 20)
+                        .foregroundColor(.red)
+                }
+                .buttonStyle(PlainButtonStyle())
+                .help("Click to close")
+                .frame(width: 35, height: 35)
+                
+                Spacer()
+            }
+            
+            // Additional Device Information
+            HStack{
+                Text("Additional Device Information")
+            }
+            .padding(.vertical, 1)
+
+            // Username
+            HStack{
+                Text("Username: ")
+                Text(self.systemConsoleUsername)
+                    .foregroundColor(.secondary)
+            }
+            .padding(.vertical, 1)
+
+            // Serial Number
+            HStack{
+                Text("Serial Number: ")
+                Text(self.serialNumber)
+                    .foregroundColor(.secondary)
+            }
+            .padding(.vertical, 1)
+
+            // Architecture
+            HStack{
+                Text("Architecture: ")
+                Text(self.cpuType)
+                    .foregroundColor(.secondary)
+            }
+            
+            Spacer()
+        }
+        .frame(width: 350, height: 175)
     }
 }
 

--- a/Nudge/Nudge.swift
+++ b/Nudge/Nudge.swift
@@ -20,9 +20,9 @@ struct Nudge: View {
     @State var serialNumber = Utils().getSerialNumber()
     @State var cpuType = Utils().getCPUTypeString()
     @State var daysRemaining = Utils().getNumberOfDaysBetween()
-    @State var requireDualCloseButtons = Utils().requireDualCloseButtons()
+    @State var requireDualQuitButtons = Utils().requireDualQuitButtons()
     @State var pastRequiredInstallationDate = Utils().pastRequiredInstallationDate()
-    @State var hasAcceptedIUnderstand = false
+    @State var hasClickedSecondaryQuitButton = false
     @State var deferralCountUI = 0
     
     // Modal view for screenshot
@@ -96,18 +96,18 @@ struct Nudge: View {
                 }
                 .padding(.vertical, 2)
                 
-                // Update Device button
+                // actionButton
                 Button(action: Utils().updateDevice, label: {
-                    Text("Update Device")
+                    Text(actionButtonText)
                         .frame(minWidth: 100)
                   }
                 )
                 .keyboardShortcut(.defaultAction)
                 .padding(.vertical, 2)
 
-                // OK button
+                // primaryQuitButton
                 Button(action: {AppKit.NSApp.terminate(nil)}, label: {
-                    Text("OK")
+                    Text(primaryQuitButtonText)
                         .frame(minWidth: 100)
                     }
                 )
@@ -118,9 +118,10 @@ struct Nudge: View {
                 HStack {
                     // Force the button to the right with a spacer
                     Spacer()
+                    // informationButton
                     if informationButtonPath != "" {
                         Button(action: Utils().openMoreInfo, label: {
-                            Text("More Info")
+                            Text(informationButtonText)
                           }
                         )
                         .buttonStyle(BorderlessButtonStyle())
@@ -225,7 +226,7 @@ struct Nudge: View {
 
                         // Days Remaining
                         HStack{
-                            Text("Days Remaining: ")
+                            Text("Days remaining to update: ")
                             Spacer()
                             if self.daysRemaining <= 0 {
                                 Text(String(0))
@@ -259,9 +260,10 @@ struct Nudge: View {
                     // More Info
                     // https://developer.apple.com/documentation/swiftui/openurlaction
                     HStack(alignment: .top) {
+                        // informationButton
                         if informationButtonPath != "" {
                             Button(action: Utils().openMoreInfo, label: {
-                                Text("More Info")
+                                Text(informationButtonText)
                               }
                             )
                             .buttonStyle(BorderlessButtonStyle())
@@ -375,9 +377,9 @@ struct Nudge: View {
 
                     // Bottom buttons
                     HStack {
-                        // Update Device button
+                        // actionButton
                         Button(action: Utils().updateDevice, label: {
-                            Text("Update Device")
+                            Text(actionButtonText)
                           }
                         )
                         .keyboardShortcut(.defaultAction)
@@ -386,43 +388,43 @@ struct Nudge: View {
                         Spacer()
                         
                         if Utils().demoModeEnabled() || !pastRequiredInstallationDate && allowedDeferrals > self.deferralCountUI {
-                            // I understand button
-                            if requireDualCloseButtons {
-                                if self.hasAcceptedIUnderstand {
+                            // secondaryQuitButton
+                            if requireDualQuitButtons {
+                                if self.hasClickedSecondaryQuitButton {
                                     Button(action: {}, label: {
-                                        Text("I understand")
+                                        Text(secondaryQuitButtonText)
                                       }
                                     )
                                     .hidden()
                                 } else {
                                     Button(action: {
-                                        hasAcceptedIUnderstand = true
+                                        hasClickedSecondaryQuitButton = true
                                     }, label: {
-                                        Text("I understand")
+                                        Text(secondaryQuitButtonText)
                                       }
                                     )
                                 }
                             } else {
                                 Button(action: {}, label: {
-                                    Text("I understand")
+                                    Text(secondaryQuitButtonText)
                                   }
                                 )
                                 .hidden()
                             }
                         
-                            // OK button
-                            if requireDualCloseButtons {
-                                if self.hasAcceptedIUnderstand {
+                            // primaryQuitButton
+                            if requireDualQuitButtons {
+                                if self.hasClickedSecondaryQuitButton {
                                     Button(action: {AppKit.NSApp.terminate(nil)}, label: {
-                                        Text("OK")
+                                        Text(primaryQuitButtonText)
                                             .frame(minWidth: 35)
                                       }
                                     )
                                 } else {
                                     Button(action: {
-                                        hasAcceptedIUnderstand = true
+                                        hasClickedSecondaryQuitButton = true
                                     }, label: {
-                                        Text("OK")
+                                        Text(primaryQuitButtonText)
                                             .frame(minWidth: 35)
                                       }
                                     )
@@ -430,7 +432,7 @@ struct Nudge: View {
                                 }
                             } else {
                                 Button(action: {AppKit.NSApp.terminate(nil)}, label: {
-                                    Text("OK")
+                                    Text(primaryQuitButtonText)
                                         .frame(minWidth: 35)
                                   }
                                 )

--- a/Nudge/Nudge.swift
+++ b/Nudge/Nudge.swift
@@ -532,6 +532,7 @@ struct deviceInfo: View {
             // Additional Device Information
             HStack{
                 Text("Additional Device Information")
+                    .fontWeight(.bold)
             }
             .padding(.vertical, 1)
 

--- a/Nudge/Utils.swift
+++ b/Nudge/Utils.swift
@@ -162,7 +162,7 @@ struct Utils {
         return getCurrentDate() > requiredInstallationDate
     }
     
-    func requireDualCloseButtons() -> Bool {
+    func requireDualQuitButtons() -> Bool {
         return (approachingWindowTime / 24) >= getNumberOfDaysBetween()
     }
 

--- a/Nudge/Utils.swift
+++ b/Nudge/Utils.swift
@@ -151,7 +151,7 @@ struct Utils {
     }
 
     func openMoreInfo() {
-        guard let url = URL(string: informationButtonPath) else {
+        guard let url = URL(string: aboutUpdateURL) else {
             return
         }
         print("User clicked moreInfo button.")

--- a/Nudge/defaults.swift
+++ b/Nudge/defaults.swift
@@ -19,7 +19,6 @@ let attemptToFetchMajorUpgrade = nudgePreferences?.optionalFeatures?.attemptToFe
 let enforceMinorUpdates = nudgePreferences?.optionalFeatures?.enforceMinorUpdates ?? true
 let iconDarkPath = nudgePreferences?.optionalFeatures?.iconDarkPath ?? ""
 let iconLightPath = nudgePreferences?.optionalFeatures?.iconLightPath ?? ""
-let informationButtonPath = nudgePreferences?.optionalFeatures?.informationButtonPath ?? "https://github.com/erikng/NudgeSwift"
 let maxRandomDelayInSeconds = nudgePreferences?.optionalFeatures?.maxRandomDelayInSeconds ?? 1200
 let noTimers = nudgePreferences?.optionalFeatures?.noTimers ?? false
 let randomDelay = nudgePreferences?.optionalFeatures?.randomDelay ?? false
@@ -43,6 +42,7 @@ let uamdmScreenShotPath = nudgePreferences?.optionalFeatures?.mdmFeatures?.uamdm
 let majorUpgradeAppPath = getOSVersionRequirements()?.majorUpgradeAppPath ?? ""
 let requiredInstallationDate = getOSVersionRequirements()?.requiredInstallationDate ?? Date(timeIntervalSince1970: 0)
 let requiredMinimumOSVersion = getOSVersionRequirements()?.requiredMinimumOSVersion ?? "0.0"
+let aboutUpdateURL = getOSVersionRequirements()?.aboutUpdateURL ?? "https://support.apple.com/en-us/HT201541"
 func getOSVersionRequirements() -> OSVersionRequirement? {
     let requirements = nudgePreferences?.osVersionRequirements
     if requirements != nil {
@@ -68,17 +68,17 @@ let nudgeRefreshCycle = nudgePreferences?.userExperience?.nudgeRefreshCycle ?? 6
 let actionButtonText = nudgePreferences?.userInterface?.updateElements?.actionButtonText ?? "Update Device"
 func getMainHeader() -> String {
     if Utils().demoModeEnabled() {
-        return "macOS Update Available (Demo Mode)"
+        return "Your device requires a security update (Demo Mode)"
     } else {
-        return nudgePreferences?.userInterface?.updateElements?.mainHeader ?? "macOS Update Available"
+        return nudgePreferences?.userInterface?.updateElements?.mainHeader ?? "Your device requires a security update"
     }
 }
 let informationButtonText = nudgePreferences?.userInterface?.updateElements?.informationButtonText ?? "More Info"
-let lowerHeader = nudgePreferences?.userInterface?.updateElements?.lowerHeader ?? "Ready to start the update?"
-let lowerSubHeader = nudgePreferences?.userInterface?.updateElements?.lowerSubHeader ?? "Click on the 'Update Device' button below."
-let mainContentHeader = nudgePreferences?.userInterface?.updateElements?.mainContentHeader ?? "A security update is required on your device."
+let mainContentHeader = nudgePreferences?.userInterface?.updateElements?.mainContentHeader ?? "Your device will restart during this update"
+let mainContentNote = nudgePreferences?.userInterface?.updateElements?.mainContentNote ?? "Important Notes"
+let mainContentSubHeader = nudgePreferences?.userInterface?.updateElements?.mainContentSubHeader ?? "Updates can take up to 30 minutes to complete"
 let mainContentText = nudgePreferences?.userInterface?.updateElements?.mainContentText ?? "A fully up-to-date device is required to ensure that IT can your accurately protect your device. \n\nIf you do not update your device, you may lose access to some items necessary for your day-to-day tasks. \n\nTo begin the update, simply click on the button below and follow the provided steps."
-let primaryQuitButtonText = nudgePreferences?.userInterface?.updateElements?.primaryQuitButtonText ?? "Okay"
+let primaryQuitButtonText = nudgePreferences?.userInterface?.updateElements?.primaryQuitButtonText ?? "Defer"
 let secondaryQuitButtonText = nudgePreferences?.userInterface?.updateElements?.secondaryQuitButtonText ?? "I understand"
 let subHeader = nudgePreferences?.userInterface?.updateElements?.subHeader ?? "A friendly reminder from your local IT team"
 

--- a/Nudge/defaults.swift
+++ b/Nudge/defaults.swift
@@ -25,6 +25,7 @@ let noTimers = nudgePreferences?.optionalFeatures?.noTimers ?? false
 let randomDelay = nudgePreferences?.optionalFeatures?.randomDelay ?? false
 let screenShotDarkPath = nudgePreferences?.optionalFeatures?.screenShotDarkPath ?? ""
 let screenShotLightPath = nudgePreferences?.optionalFeatures?.screenShotLightPath ?? ""
+let simpleMode = nudgePreferences?.optionalFeatures?.simpleMode ?? false
 
 // optionalFeatures - MDM
 let alwaysShowManualEnrllment = nudgePreferences?.optionalFeatures?.mdmFeatures?.alwaysShowManulEnrollment ?? false
@@ -68,7 +69,7 @@ let actionButtonText = nudgePreferences?.userInterface?.updateElements?.actionBu
 let informationButtonText = nudgePreferences?.userInterface?.updateElements?.informationButtonText ?? "More Info"
 let lowerHeader = nudgePreferences?.userInterface?.updateElements?.lowerHeader ?? "Ready to start the update?"
 let lowerSubHeader = nudgePreferences?.userInterface?.updateElements?.lowerSubHeader ?? "Click on the 'Update Device' button below."
-let mainContentHeader = nudgePreferences?.userInterface?.updateElements?.mainContentHeader ?? "A security update is required on your machine."
+let mainContentHeader = nudgePreferences?.userInterface?.updateElements?.mainContentHeader ?? "A security update is required on your device."
 let mainContentText = nudgePreferences?.userInterface?.updateElements?.mainContentText ?? "A fully up-to-date device is required to ensure that IT can your accurately protect your device. \n\nIf you do not update your device, you may lose access to some items necessary for your day-to-day tasks. \n\nTo begin the update, simply click on the button below and follow the provided steps."
 let mainHeader = nudgePreferences?.userInterface?.updateElements?.mainHeader ?? "macOS Update Available (Demo Mode)"
 let primaryQuitButtonText = nudgePreferences?.userInterface?.updateElements?.primaryQuitButtonText ?? "Okay"

--- a/Nudge/defaults.swift
+++ b/Nudge/defaults.swift
@@ -66,12 +66,18 @@ let nudgeRefreshCycle = nudgePreferences?.userExperience?.nudgeRefreshCycle ?? 6
 
 // userInterface
 let actionButtonText = nudgePreferences?.userInterface?.updateElements?.actionButtonText ?? "Update Device"
+func getMainHeader() -> String {
+    if Utils().demoModeEnabled() {
+        return "macOS Update Available (Demo Mode)"
+    } else {
+        return nudgePreferences?.userInterface?.updateElements?.mainHeader ?? "macOS Update Available"
+    }
+}
 let informationButtonText = nudgePreferences?.userInterface?.updateElements?.informationButtonText ?? "More Info"
 let lowerHeader = nudgePreferences?.userInterface?.updateElements?.lowerHeader ?? "Ready to start the update?"
 let lowerSubHeader = nudgePreferences?.userInterface?.updateElements?.lowerSubHeader ?? "Click on the 'Update Device' button below."
 let mainContentHeader = nudgePreferences?.userInterface?.updateElements?.mainContentHeader ?? "A security update is required on your device."
 let mainContentText = nudgePreferences?.userInterface?.updateElements?.mainContentText ?? "A fully up-to-date device is required to ensure that IT can your accurately protect your device. \n\nIf you do not update your device, you may lose access to some items necessary for your day-to-day tasks. \n\nTo begin the update, simply click on the button below and follow the provided steps."
-let mainHeader = nudgePreferences?.userInterface?.updateElements?.mainHeader ?? "macOS Update Available (Demo Mode)"
 let primaryQuitButtonText = nudgePreferences?.userInterface?.updateElements?.primaryQuitButtonText ?? "Okay"
 let secondaryQuitButtonText = nudgePreferences?.userInterface?.updateElements?.secondaryQuitButtonText ?? "I understand"
 let subHeader = nudgePreferences?.userInterface?.updateElements?.subHeader ?? "A friendly reminder from your local IT team"

--- a/Nudge/example.json
+++ b/Nudge/example.json
@@ -22,7 +22,8 @@
         "noTimers": false,
         "randomDelay": false,
         "screenShotDarkPath": "/Library/Application Support/nudge/screenShotDark.jpg",
-        "screenShotLightPath": "/Library/Application Support/nudge/screenShotLight.jpg"
+        "screenShotLightPath": "/Library/Application Support/nudge/screenShotLight.jpg",
+        "simpleMode": false
     },
     "osVersionRequirements": [
         {

--- a/Nudge/example.json
+++ b/Nudge/example.json
@@ -6,7 +6,6 @@
         "enforceMinorUpdates": true,
         "iconDarkPath": "/Library/Application Support/nudge/logoDark.png",
         "iconLightPath": "/Library/Application Support/nudge/logoLight.png",
-        "informationButtonPath": "https://github.com/erikng/NudgeSwift",
         "mdmFeatures": {
             "alwaysShowManulEnrollment": false,
             "depScreenShotPath": "/Library/Application Support/nudge/depScreenShot.jpg",
@@ -27,6 +26,7 @@
     },
     "osVersionRequirements": [
         {
+            "aboutUpdateURL": "https://support.apple.com/en-us/HT211896",
             "majorUpgradeAppPath": "/Applications/Install macOS Big Sur.app",
             "requiredInstallationDate": "2021-02-28T00:00:00Z",
             "requiredMinimumOSVersion": "11.2.1",
@@ -72,11 +72,11 @@
         "updateElements": {
             "actionButtonText": "Update Device",
             "informationButtonText": "More Info",
-            "lowerHeader": "Ready to start the update?",
-            "lowerSubHeader": "Click on the 'Update Device' button below.",
-            "mainContentHeader": "A security update is required on your machine.",
+            "mainContentHeader": "Your device will restart during this update",
+            "mainContentNote": "Important Notes",
+            "mainContentSubHeader": "Updates can take up to 30 minutes to complete",
             "mainContentText": "A fully up-to-date device is required to ensure that IT can your accurately protect your device. \n\nIf you do not update your device, you may lose access to some items necessary for your day-to-day tasks. \n\nTo begin the update, simply click on the button below and follow the provided steps.",
-            "mainHeader": "macOS Update Available",
+            "mainHeader": "Your device requires a security update",
             "primaryQuitButtonText": "Okay",
             "secondaryQuitButtonText": "I understand",
             "subHeader": "A friendly reminder from your local IT team"

--- a/Nudge/nudgePrefs.swift
+++ b/Nudge/nudgePrefs.swift
@@ -96,6 +96,7 @@ struct OptionalFeatures: Codable {
     var mdmFeatures: MdmFeatures?
     var noTimers, randomDelay: Bool?
     var screenShotDarkPath, screenShotLightPath: String?
+    var simpleMode: Bool?
 }
 
 // MARK: OptionalFeatures convenience initializers and mutators
@@ -129,7 +130,8 @@ extension OptionalFeatures {
         noTimers: Bool?? = nil,
         randomDelay: Bool?? = nil,
         screenShotDarkPath: String?? = nil,
-        screenShotLightPath: String?? = nil
+        screenShotLightPath: String?? = nil,
+        simpleMode: Bool?? = nil
     ) -> OptionalFeatures {
         return OptionalFeatures(
             allowedDeferrals: allowedDeferrals ?? self.allowedDeferrals,
@@ -144,7 +146,8 @@ extension OptionalFeatures {
             noTimers: noTimers ?? self.noTimers,
             randomDelay: randomDelay ?? self.randomDelay,
             screenShotDarkPath: screenShotDarkPath ?? self.screenShotDarkPath,
-            screenShotLightPath: screenShotLightPath ?? self.screenShotLightPath
+            screenShotLightPath: screenShotLightPath ?? self.screenShotLightPath,
+            simpleMode: simpleMode ?? self.simpleMode
         )
     }
 

--- a/Nudge/nudgePrefs.swift
+++ b/Nudge/nudgePrefs.swift
@@ -224,6 +224,7 @@ extension MdmFeatures {
 
 // MARK: - OSVersionRequirement
 struct OSVersionRequirement: Codable {
+    var aboutUpdateURL: String?
     var majorUpgradeAppPath: String?
     var requiredInstallationDate: Date?
     var requiredMinimumOSVersion: String?
@@ -234,7 +235,8 @@ struct OSVersionRequirement: Codable {
 
 extension OSVersionRequirement {
     enum Keys: String {
-        case majorUpgradeAppPath,
+        case aboutUpdateURL,
+             majorUpgradeAppPath,
              requiredInstallationDate,
              requiredMinimumOSVersion,
              targetedOSVersions
@@ -263,12 +265,14 @@ extension OSVersionRequirement {
     }
 
     func with(
+        aboutUpdateURL: String?? = nil,
         majorUpgradeAppPath: String?? = nil,
         requiredInstallationDate: Date?? = nil,
         requiredMinimumOSVersion: String?? = nil,
         targetedOSVersions: [String]?? = nil
     ) -> OSVersionRequirement {
         return OSVersionRequirement(
+            aboutUpdateURL: aboutUpdateURL ?? self.aboutUpdateURL,
             majorUpgradeAppPath: majorUpgradeAppPath ?? self.majorUpgradeAppPath,
             requiredInstallationDate: requiredInstallationDate ?? self.requiredInstallationDate,
             requiredMinimumOSVersion: requiredMinimumOSVersion ?? self.requiredMinimumOSVersion,
@@ -463,8 +467,8 @@ extension MdmElements {
 
 // MARK: - UpdateElements
 struct UpdateElements: Codable {
-    var actionButtonText, informationButtonText, lowerHeader, lowerSubHeader: String?
-    var mainContentHeader, mainContentText, mainHeader, primaryQuitButtonText: String?
+    var actionButtonText, informationButtonText, mainContentHeader, mainContentNote: String?
+    var mainContentSubHeader, mainContentText, mainHeader, primaryQuitButtonText: String?
     var secondaryQuitButtonText, subHeader: String?
 }
 
@@ -489,9 +493,9 @@ extension UpdateElements {
     func with(
         actionButtonText: String?? = nil,
         informationButtonText: String?? = nil,
-        lowerHeader: String?? = nil,
-        lowerSubHeader: String?? = nil,
         mainContentHeader: String?? = nil,
+        mainContentNote: String?? = nil,
+        mainContentSubHeader: String?? = nil,
         mainContentText: String?? = nil,
         mainHeader: String?? = nil,
         primaryQuitButtonText: String?? = nil,
@@ -501,9 +505,9 @@ extension UpdateElements {
         return UpdateElements(
             actionButtonText: actionButtonText ?? self.actionButtonText,
             informationButtonText: informationButtonText ?? self.informationButtonText,
-            lowerHeader: lowerHeader ?? self.lowerHeader,
-            lowerSubHeader: lowerSubHeader ?? self.lowerSubHeader,
             mainContentHeader: mainContentHeader ?? self.mainContentHeader,
+            mainContentNote: mainContentNote ?? self.mainContentNote,
+            mainContentSubHeader: mainContentSubHeader ?? self.mainContentSubHeader,
             mainContentText: mainContentText ?? self.mainContentText,
             mainHeader: mainHeader ?? self.mainHeader,
             primaryQuitButtonText: primaryQuitButtonText ?? self.primaryQuitButtonText,

--- a/en.lproj/Localizable.strings
+++ b/en.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 
 "Current OS Version: " = "Current OS Version: ";
 
-"Days Remaining: " = "Days Remaining: ";
+"Days remaining to update: " = "Days remaining to update: ";
 
 "Deferral Count: " = "Deferral Count: ";
 

--- a/en.lproj/Localizable.strings
+++ b/en.lproj/Localizable.strings
@@ -30,7 +30,7 @@
 
 "More Info" = "More Info";
 
-"OK" = "OK";
+"Defer" = "Defer";
 
 "Ready to start the update?" = "Ready to start the update?";
 

--- a/fr.lproj/Localizable.strings
+++ b/fr.lproj/Localizable.strings
@@ -30,7 +30,7 @@
 
 "More Info" = "Plus d'informations";
 
-"OK" = "Oui";
+"Defer" = "Différer";
 
 "Ready to start the update?" = "Prêt à démarrer la mise à jour??";
 

--- a/fr.lproj/Localizable.strings
+++ b/fr.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 
 "Current OS Version: " = "Version actuelle du système d'exploitation: ";
 
-"Days Remaining: " = "Jours restant: ";
+"Days remaining to update: " = "Jours restant: ";
 
 "Deferral Count: " = "Jours restant: ";
 


### PR DESCRIPTION
Simple Mode
<img width="1012" alt="Screen Shot 2021-02-12 at 5 45 47 PM" src="https://user-images.githubusercontent.com/5685016/107833847-2c246900-6d5a-11eb-977a-b120baa96624.png">

New UI
<img width="1012" alt="Screen Shot 2021-02-12 at 5 38 56 PM" src="https://user-images.githubusercontent.com/5685016/107833851-3181b380-6d5a-11eb-86f0-56f972376d5b.png">
New UI sheet (question mark at the top left corner)
<img width="1012" alt="Screen Shot 2021-02-12 at 5 41 56 PM" src="https://user-images.githubusercontent.com/5685016/107833861-35add100-6d5a-11eb-8258-c470791a7914.png">

- update device button is at the top
- OK is now Defer.
- More info button now matches simple mode
- More info button is now tied to the OS requirement hash

example

```json
    "osVersionRequirements": [
        {
            "aboutUpdateURL": "hhttps://support.apple.com/en-us/HT211896#macos1121",
            "majorUpgradeAppPath": "/Applications/Install macOS Big Sur.app",
            "requiredInstallationDate": "2021-03-12T00:00:00Z",
            "requiredMinimumOSVersion": "11.2.1",
            "targetedOSVersions": [
                "11.0",
                "11.0.1",
                "11.1",
                "11.2"
            ]
        }
    ],
```

Some keys were deleted and others were renamed after simplifying.