### PR TITLE
Add a dynamic UI method for localization

### DIFF
--- a/Nudge.xcodeproj/project.pbxproj
+++ b/Nudge.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		639E194925CC7F13008F618B /* example.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = example.json; sourceTree = "<group>"; };
 		639E198125CD885D008F618B /* nudgePrefs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = nudgePrefs.swift; sourceTree = "<group>"; };
 		639E198925CD9E21008F618B /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
+		63B6FDBF25D785010038E81C /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		63D7D0DF25C9E9A400236281 /* Nudge.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Nudge.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		63D7D0E225C9E9A400236281 /* NudgeApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NudgeApp.swift; sourceTree = "<group>"; };
 		63D7D0E425C9E9A400236281 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -247,8 +248,8 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
-				Base,
 				fr,
+				es,
 			);
 			mainGroup = 63D7D0D625C9E9A400236281;
 			productRefGroup = 63D7D0E025C9E9A400236281 /* Products */;
@@ -345,6 +346,7 @@
 			children = (
 				5870FF6325CFE5EC0036D203 /* en */,
 				5870FF6825CFE5FA0036D203 /* fr */,
+				63B6FDBF25D785010038E81C /* es */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";

--- a/Nudge/Nudge.swift
+++ b/Nudge/Nudge.swift
@@ -555,6 +555,14 @@ struct deviceInfo: View {
                 Text(self.cpuType)
                     .foregroundColor(.secondary)
             }
+            .padding(.vertical, 1)
+            
+            // Language
+            HStack{
+                Text("Language:")
+                Text(language)
+                    .foregroundColor(.secondary)
+            }
             
             Spacer()
         }
@@ -568,13 +576,13 @@ struct deviceInfo: View {
 struct Nudge_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            Nudge().environmentObject(PolicyManager(withVersion:  try! OSVersion("11.2") ))
-                .preferredColorScheme(.light)
+            ForEach(["en", "fr"], id: \.self) { id in
+                Nudge().environmentObject(PolicyManager(withVersion:  try! OSVersion("11.2") ))
+                    .preferredColorScheme(.light)
+                    .environment(\.locale, .init(identifier: id))
+            }
             Nudge().environmentObject(PolicyManager(withVersion:  try! OSVersion("11.2") ))
                 .preferredColorScheme(.dark)
-            Nudge().environmentObject(PolicyManager(withVersion:  try! OSVersion("11.2") ))
-                .preferredColorScheme(.dark)
-                .environment(\.locale, .init(identifier: "fr"))
         }
     }
 }

--- a/Nudge/Nudge.swift
+++ b/Nudge/Nudge.swift
@@ -576,7 +576,7 @@ struct deviceInfo: View {
 struct Nudge_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            ForEach(["en", "fr"], id: \.self) { id in
+            ForEach(["en", "es", "fr"], id: \.self) { id in
                 Nudge().environmentObject(PolicyManager(withVersion:  try! OSVersion("11.2") ))
                     .preferredColorScheme(.light)
                     .environment(\.locale, .init(identifier: id))

--- a/Nudge/defaults.swift
+++ b/Nudge/defaults.swift
@@ -65,22 +65,34 @@ let initialRefreshCycle = nudgePreferences?.userExperience?.initialRefreshCycle 
 let nudgeRefreshCycle = nudgePreferences?.userExperience?.nudgeRefreshCycle ?? 60
 
 // userInterface
-let actionButtonText = nudgePreferences?.userInterface?.updateElements?.actionButtonText ?? "Update Device"
+let language = NSLocale.current.languageCode!
+func getuserInterface() -> UpdateElement? {
+    let updateElements = nudgePreferences?.userInterface?.updateElements
+    if updateElements != nil {
+        for (_ , subPreferences) in updateElements!.enumerated() {
+            if subPreferences.language == language {
+                return subPreferences
+            }
+        }
+    }
+    return nil
+}
+let actionButtonText = getuserInterface()?.actionButtonText ?? "Update Device"
 func getMainHeader() -> String {
     if Utils().demoModeEnabled() {
         return "Your device requires a security update (Demo Mode)"
     } else {
-        return nudgePreferences?.userInterface?.updateElements?.mainHeader ?? "Your device requires a security update"
+        return getuserInterface()?.mainHeader ?? "Your device requires a security update"
     }
 }
-let informationButtonText = nudgePreferences?.userInterface?.updateElements?.informationButtonText ?? "More Info"
-let mainContentHeader = nudgePreferences?.userInterface?.updateElements?.mainContentHeader ?? "Your device will restart during this update"
-let mainContentNote = nudgePreferences?.userInterface?.updateElements?.mainContentNote ?? "Important Notes"
-let mainContentSubHeader = nudgePreferences?.userInterface?.updateElements?.mainContentSubHeader ?? "Updates can take around 30 minutes to complete"
-let mainContentText = nudgePreferences?.userInterface?.updateElements?.mainContentText ?? "A fully up-to-date device is required to ensure that IT can your accurately protect your device. \n\nIf you do not update your device, you may lose access to some items necessary for your day-to-day tasks. \n\nTo begin the update, simply click on the button below and follow the provided steps."
-let primaryQuitButtonText = nudgePreferences?.userInterface?.updateElements?.primaryQuitButtonText ?? "Later"
-let secondaryQuitButtonText = nudgePreferences?.userInterface?.updateElements?.secondaryQuitButtonText ?? "I understand"
-let subHeader = nudgePreferences?.userInterface?.updateElements?.subHeader ?? "A friendly reminder from your local IT team"
+let informationButtonText = getuserInterface()?.informationButtonText ?? "More Info"
+let mainContentHeader = getuserInterface()?.mainContentHeader ?? "Your device will restart during this update"
+let mainContentNote = getuserInterface()?.mainContentNote ?? "Important Notes"
+let mainContentSubHeader = getuserInterface()?.mainContentSubHeader ?? "Updates can take around 30 minutes to complete"
+let mainContentText = getuserInterface()?.mainContentText ?? "A fully up-to-date device is required to ensure that IT can your accurately protect your device. \n\nIf you do not update your device, you may lose access to some items necessary for your day-to-day tasks. \n\nTo begin the update, simply click on the button below and follow the provided steps."
+let primaryQuitButtonText = getuserInterface()?.primaryQuitButtonText ?? "Later"
+let secondaryQuitButtonText = getuserInterface()?.secondaryQuitButtonText ?? "I understand"
+let subHeader = getuserInterface()?.subHeader ?? "A friendly reminder from your local IT team"
 
 // userInterface - MDM
 let mdmActionButtonManualText = nudgePreferences?.userInterface?.mdmElements?.actionButtonManualText ?? "Manually Enroll"

--- a/Nudge/example.json
+++ b/Nudge/example.json
@@ -6,6 +6,7 @@
         "enforceMinorUpdates": true,
         "iconDarkPath": "/Library/Application Support/nudge/logoDark.png",
         "iconLightPath": "/Library/Application Support/nudge/logoLight.png",
+        "maxRandomDelayInSeconds": 1200,
         "mdmFeatures": {
             "alwaysShowManulEnrollment": false,
             "depScreenShotPath": "/Library/Application Support/nudge/depScreenShot.jpg",
@@ -17,7 +18,6 @@
             "mdmRequiredInstallationDate": "2021-02-28T00:00:00Z",
             "uamdmScreenShotPath": "/Library/Application Support/nudge/uamdmScreenShot.jpg"
         },
-        "maxRandomDelayInSeconds": 1200,
         "noTimers": false,
         "randomDelay": false,
         "screenShotDarkPath": "/Library/Application Support/nudge/screenShotDark.jpg",
@@ -69,17 +69,33 @@
             "secondaryQuitButtonText": "I understand",
             "subHeader": "A friendly reminder from your local IT team"
         },
-        "updateElements": {
-            "actionButtonText": "Update Device",
-            "informationButtonText": "More Info",
-            "mainContentHeader": "Your device will restart during this update",
-            "mainContentNote": "Important Notes",
-            "mainContentSubHeader": "Updates can take around 30 minutes to complete",
-            "mainContentText": "A fully up-to-date device is required to ensure that IT can your accurately protect your device. \n\nIf you do not update your device, you may lose access to some items necessary for your day-to-day tasks. \n\nTo begin the update, simply click on the button below and follow the provided steps.",
-            "mainHeader": "Your device requires a security update",
-            "primaryQuitButtonText": "Later",
-            "secondaryQuitButtonText": "I understand",
-            "subHeader": "A friendly reminder from your local IT team"
-        }
+        "updateElements": [
+            {
+                "_language": "en",
+                "actionButtonText": "Update Device",
+                "informationButtonText": "More Info",
+                "mainContentHeader": "Your device will restart during this update",
+                "mainContentNote": "Important Notes",
+                "mainContentSubHeader": "Updates can take around 30 minutes to complete",
+                "mainContentText": "A fully up-to-date device is required to ensure that IT can your accurately protect your device.\n\nIf you do not update your device, you may lose access to some items necessary for your day-to-day tasks.\n\nTo begin the update, simply click on the button below and follow the provided steps.",
+                "mainHeader": "Your device requires a security update",
+                "primaryQuitButtonText": "Later",
+                "secondaryQuitButtonText": "I understand",
+                "subHeader": "A friendly reminder from your local IT team"
+            },
+            {
+                "_language": "fr",
+                "actionButtonText": "Mettre à jour l'appareil",
+                "informationButtonText": "Plus d'informations",
+                "mainContentHeader": "Votre appareil redémarrera pendant cette mise à jour",
+                "mainContentNote": "Notes Importantes",
+                "mainContentSubHeader": "Les mises à jour peuvent prendre environ 30 minutes.",
+                "mainContentText": "Un appareil entièrement à jour est nécessaire pour garantir que le service informatique peut protéger votre appareil avec précision.\n\n Si vous ne mettez pas à jour votre appareil, vous risquez de perdre l'accès à certains éléments nécessaires à vos tâches quotidiennes.\n\nPour commencer la mise à jour, cliquez simplement sur le bouton ci-dessous et suivez les étapes fournies.",
+                "mainHeader": "Votre appareil nécessite une mise à jour de sécurité",
+                "primaryQuitButtonText": "Plus tard",
+                "secondaryQuitButtonText": "Je comprends",
+                "subHeader": "Un rappel amical de votre équipe informatique locale"
+            }
+        ]
     }
 }

--- a/Nudge/nudgePrefs.swift
+++ b/Nudge/nudgePrefs.swift
@@ -91,7 +91,6 @@ struct OptionalFeatures: Codable {
     var allowedDeferrals, allowedDeferralsUntilForcedSecondaryQuitButton: Int?
     var attemptToFetchMajorUpgrade, enforceMinorUpdates: Bool?
     var iconDarkPath, iconLightPath: String?
-    var informationButtonPath: String?
     var maxRandomDelayInSeconds: Int?
     var mdmFeatures: MdmFeatures?
     var noTimers, randomDelay: Bool?
@@ -124,7 +123,6 @@ extension OptionalFeatures {
         enforceMinorUpdates: Bool?? = nil,
         iconDarkPath: String?? = nil,
         iconLightPath: String?? = nil,
-        informationButtonPath: String?? = nil,
         maxRandomDelayInSeconds: Int?? = nil,
         mdmFeatures: MdmFeatures?? = nil,
         noTimers: Bool?? = nil,
@@ -140,7 +138,6 @@ extension OptionalFeatures {
             enforceMinorUpdates: enforceMinorUpdates ?? self.enforceMinorUpdates,
             iconDarkPath: iconDarkPath ?? self.iconDarkPath,
             iconLightPath: iconLightPath ?? self.iconLightPath,
-            informationButtonPath: informationButtonPath ?? self.informationButtonPath,
             maxRandomDelayInSeconds: maxRandomDelayInSeconds ?? self.maxRandomDelayInSeconds,
             mdmFeatures: mdmFeatures ?? self.mdmFeatures,
             noTimers: noTimers ?? self.noTimers,
@@ -234,21 +231,6 @@ struct OSVersionRequirement: Codable {
 // MARK: OSVersionRequirement convenience initializers and mutators
 
 extension OSVersionRequirement {
-    enum Keys: String {
-        case aboutUpdateURL,
-             majorUpgradeAppPath,
-             requiredInstallationDate,
-             requiredMinimumOSVersion,
-             targetedOSVersions
-    }
-    
-//    init(_ dict: [String: Any]) throws {
-//        self.majorUpgradeAppPath = try dict.nudgeDefault(Keys.majorUpgradeAppPath.rawValue)
-//        self.requiredInstallationDate = try dict.nudgeDefault(Keys.requiredInstallationDate.rawValue)
-//        self.requiredMinimumOSVersion = try dict.nudgeDefault(Keys.requiredMinimumOSVersion.rawValue)
-//        self.targetedOSVersions = try dict.nudgeDefault(Keys.targetedOSVersions.rawValue)
-//    }
-    
     init(data: Data) throws {
         self = try newJSONDecoder().decode(OSVersionRequirement.self, from: data)
     }
@@ -345,7 +327,7 @@ extension UserExperience {
 // MARK: - UserInterface
 struct UserInterface: Codable {
     var mdmElements: MdmElements?
-    var updateElements: UpdateElements?
+    var updateElements: [UpdateElement]?
 }
 
 // MARK: UserInterface convenience initializers and mutators
@@ -368,7 +350,7 @@ extension UserInterface {
 
     func with(
         mdmElements: MdmElements?? = nil,
-        updateElements: UpdateElements?? = nil
+        updateElements: [UpdateElement]?? = nil
     ) -> UserInterface {
         return UserInterface(
             mdmElements: mdmElements ?? self.mdmElements,
@@ -465,18 +447,23 @@ extension MdmElements {
     }
 }
 
-// MARK: - UpdateElements
-struct UpdateElements: Codable {
-    var actionButtonText, informationButtonText, mainContentHeader, mainContentNote: String?
-    var mainContentSubHeader, mainContentText, mainHeader, primaryQuitButtonText: String?
-    var secondaryQuitButtonText, subHeader: String?
+// MARK: - UpdateElement
+struct UpdateElement: Codable {
+    var language, actionButtonText, informationButtonText, mainContentHeader: String?
+    var mainContentNote, mainContentSubHeader, mainContentText, mainHeader: String?
+    var primaryQuitButtonText, secondaryQuitButtonText, subHeader: String?
+
+    enum CodingKeys: String, CodingKey {
+        case language = "_language"
+        case actionButtonText, informationButtonText, mainContentHeader, mainContentNote, mainContentSubHeader, mainContentText, mainHeader, primaryQuitButtonText, secondaryQuitButtonText, subHeader
+    }
 }
 
-// MARK: UpdateElements convenience initializers and mutators
+// MARK: UpdateElement convenience initializers and mutators
 
-extension UpdateElements {
+extension UpdateElement {
     init(data: Data) throws {
-        self = try newJSONDecoder().decode(UpdateElements.self, from: data)
+        self = try newJSONDecoder().decode(UpdateElement.self, from: data)
     }
 
     init(_ json: String, using encoding: String.Encoding = .utf8) throws {
@@ -491,6 +478,7 @@ extension UpdateElements {
     }
 
     func with(
+        language: String?? = nil,
         actionButtonText: String?? = nil,
         informationButtonText: String?? = nil,
         mainContentHeader: String?? = nil,
@@ -501,8 +489,9 @@ extension UpdateElements {
         primaryQuitButtonText: String?? = nil,
         secondaryQuitButtonText: String?? = nil,
         subHeader: String?? = nil
-    ) -> UpdateElements {
-        return UpdateElements(
+    ) -> UpdateElement {
+        return UpdateElement(
+            language: language ?? self.language,
             actionButtonText: actionButtonText ?? self.actionButtonText,
             informationButtonText: informationButtonText ?? self.informationButtonText,
             mainContentHeader: mainContentHeader ?? self.mainContentHeader,

--- a/en.lproj/Localizable.strings
+++ b/en.lproj/Localizable.strings
@@ -23,6 +23,6 @@
 // Required OS Version
 "Required OS Version:" = "Required OS Version:";
 // Days remaining to update
-"Days remaining to update: " = "Days remaining to update:";
+"Days remaining to update:" = "Days remaining to update:";
 // Ignored Count
 "Ignored Count:" = "Ignored Count:";

--- a/en.lproj/Localizable.strings
+++ b/en.lproj/Localizable.strings
@@ -6,47 +6,4 @@
   
 */
 
-//// userInterface -> updateElements
-// actionButtonText
-"Update Device" = "Update Device";
-// informationButtonText
-"More Info" = "More Info";
-// mainContentHeader
-"Your device will restart during this update" = "Your device will restart during this update";
-// mainContentNote
-"Important Notes" = "Important Notes";
-// mainContentSubHeader
-"Updates can take around 30 minutes to complete" = "Updates can take around 30 minutes to complete";
-// mainContentText
-"A fully up-to-date device is required to ensure that IT can your accurately protect your device. \n\nIf you do not update your device, you may lose access to some items necessary for your day-to-day tasks. \n\nTo begin the update, simply click on the button below and follow the provided steps." = "A fully up-to-date device is required to ensure that IT can your accurately protect your device. \n\nIf you do not update your device, you may lose access to some items necessary for your day-to-day tasks. \n\nTo begin the update, simply click on the button below and follow the provided steps.";
-// mainHeader
-"Your device requires a security update" = "Your device requires a security update";
-// primaryQuitButtonText
-"Later" = "Later";
-// secondaryQuitButtonText
-"I understand" = "I understand";
-// subHeader
-"A friendly reminder from your local IT team" = "A friendly reminder from your local IT team";
-
-//// Additional Device Information
-// Username
-"Username:" = "Username:";
-// Serial Number
-"Serial Number:" = "Serial Number:";
-// Architecture
-"Architecture:" = "Architecture:";
-
-//// Left side of Nudge
-// Current OS Version
-"Current OS Version:" = "Current OS Version:";
-// Required OS Version
-"Required OS Version:" = "Required OS Version";
-// Days remaining to update
-"Days remaining to update:" = "Days remaining to update:";
-// Ignored Count
-"Ignored Count:" = "Ignored Count:";
-
-
-
-
-
+"Language:" = "Language:";

--- a/en.lproj/Localizable.strings
+++ b/en.lproj/Localizable.strings
@@ -2,8 +2,27 @@
   Localizable.strings
   Nudge
 
-  Created by Rory Murdock on 7/2/21.
+  Created by Erik Gomez on 2/12/21.
   
 */
 
 "Language:" = "Language:";
+
+//// Additional Device Information
+"Additional Device Information" = "Additional Device Information";
+// Username
+"Username:" = "Username:";
+// Serial Number
+"Serial Number:" = "Serial Number:";
+// Architecture
+"Architecture:" = "Architecture:";
+
+//// Left side of Nudge
+// Current OS Version
+"Current OS Version:" = "Current OS Version:";
+// Required OS Version
+"Required OS Version:" = "Required OS Version:";
+// Days remaining to update
+"Days remaining to update: " = "Days remaining to update:";
+// Ignored Count
+"Ignored Count:" = "Ignored Count:";

--- a/es.lproj/Localizable.strings
+++ b/es.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+/* 
+  Localizable.strings
+  Nudge
+
+  Created by Erik Gomez on 2/12/21.
+  
+*/
+
+"Language:" = "Idioma:";

--- a/fr.lproj/Localizable.strings
+++ b/fr.lproj/Localizable.strings
@@ -2,7 +2,7 @@
   Localizable.strings
   Nudge
 
-  Created by Rory Murdock on 7/2/21.
+  Created by Erik Gomez on 2/12/21.
   
 */
 

--- a/fr.lproj/Localizable.strings
+++ b/fr.lproj/Localizable.strings
@@ -6,37 +6,10 @@
   
 */
 
-/*
-  Localizable.strings
-  Nudge
-
-  Created by Rory Murdock on 7/2/21.
-  
-*/
-
-//// userInterface -> updateElements
-// actionButtonText
-"Update Device" = "Mettre à jour l'appareil";
-// informationButtonText
-"More Info" = "Plus d'informations";
-// mainContentHeader
-"Your device will restart during this update" = "Votre appareil redémarrera pendant cette mise à jour";
-// mainContentNote
-"Important Notes" = "Notes Importantes";
-// mainContentSubHeader
-"Updates can take around 30 minutes to complete" = "Les mises à jour peuvent prendre environ 30 minutes.";
-// mainContentText
-"A fully up-to-date device is required to ensure that IT can your accurately protect your device. \n\nIf you do not update your device, you may lose access to some items necessary for your day-to-day tasks. \n\nTo begin the update, simply click on the button below and follow the provided steps." = "Un appareil entièrement à jour est nécessaire pour garantir que le service informatique peut protéger votre appareil avec précision. \n \ nSi vous ne mettez pas à jour votre appareil, vous risquez de perdre l'accès à certains éléments nécessaires à vos tâches quotidiennes. \n \ nPour commencer la mise à jour, cliquez simplement sur le bouton ci-dessous et suivez les étapes fournies.";
-// mainHeader
-"Your device requires a security update" = "Votre appareil nécessite une mise à jour de sécurité";
-// primaryQuitButtonText
-"Later" = "Plus tard";
-// secondaryQuitButtonText
-"I understand" = "Je comprends";
-// subHeader
-"A friendly reminder from your local IT team" = "Un rappel amical de votre équipe informatique locale";
+"Language:" = "Langue:";
 
 //// Additional Device Information
+"Additional Device Information" = "Informations supplémentaires sur l'appareil";
 // Username
 "Username:" = "Nom d'utilisateur:";
 // Serial Number

--- a/fr.lproj/Localizable.strings
+++ b/fr.lproj/Localizable.strings
@@ -23,6 +23,6 @@
 // Required OS Version
 "Required OS Version:" = "Version du système d'exploitation requise:";
 // Days remaining to update
-"Days remaining to update: " = "Jours restant:";
+"Days remaining to update:" = "Jours restant:";
 // Ignored Count
 "Ignored Count:" = "Compte ignoré:";


### PR DESCRIPTION
I've figured out a hacky but effective method for getting dynamic localization:

in your preferences do this

```
        "updateElements": [
            {
                "_language": "en",
                "actionButtonText": "Update Device",
                "informationButtonText": "More Info",
                "mainContentHeader": "Your device will restart during this update",
                "mainContentNote": "Important Notes",
                "mainContentSubHeader": "Updates can take around 30 minutes to complete",
                "mainContentText": "A fully up-to-date device is required to ensure that IT can your accurately protect your device.\n\nIf you do not update your device, you may lose access to some items necessary for your day-to-day tasks.\n\nTo begin the update, simply click on the button below and follow the provided steps.",
                "mainHeader": "Your device requires a security update",
                "primaryQuitButtonText": "Later",
                "secondaryQuitButtonText": "I understand",
                "subHeader": "A friendly reminder from your local IT team"
            },
            {
                "_language": "fr",
                "actionButtonText": "Mettre à jour l'appareil",
                "informationButtonText": "Plus d'informations",
                "mainContentHeader": "Votre appareil redémarrera pendant cette mise à jour",
                "mainContentNote": "Notes Importantes",
                "mainContentSubHeader": "Les mises à jour peuvent prendre environ 30 minutes.",
                "mainContentText": "Un appareil entièrement à jour est nécessaire pour garantir que le service informatique peut protéger votre appareil avec précision.\n\n Si vous ne mettez pas à jour votre appareil, vous risquez de perdre l'accès à certains éléments nécessaires à vos tâches quotidiennes.\n\nPour commencer la mise à jour, cliquez simplement sur le bouton ci-dessous et suivez les étapes fournies.",
                "mainHeader": "Votre appareil nécessite une mise à jour de sécurité",
                "primaryQuitButtonText": "Plus tard",
                "secondaryQuitButtonText": "Je comprends",
                "subHeader": "Un rappel amical de votre équipe informatique locale"
            }
        ]
```

and you end up with something like this

<img width="1012" alt="Screen Shot 2021-02-12 at 6 26 40 PM" src="https://user-images.githubusercontent.com/5685016/107841224-b088e300-6d7e-11eb-9896-d0cc7a07729c.png">
<img width="1012" alt="Capture d’écran 2021-02-12 à 10 01 00 PM" src="https://user-images.githubusercontent.com/5685016/107841227-b7175a80-6d7e-11eb-89b9-931665f90a9c.png">

it also works with simple mode
<img width="1012" alt="Capture d’écran 2021-02-12 à 10 04 57 PM" src="https://user-images.githubusercontent.com/5685016/107841230-c0082c00-6d7e-11eb-8f90-80c33bc29bfc.png">

It's not perfect, but good enough for a v1.