### PR TITLE
Add ability to download json and even specify a local json path

### DIFF
--- a/Nudge/Utils.swift
+++ b/Nudge/Utils.swift
@@ -8,7 +8,7 @@
 import AppKit
 import Foundation
 import SystemConfiguration
-    
+
 struct Utils {
     func activateNudge() {
         print("Re-activating Nudge")

--- a/Nudge/Utils.swift
+++ b/Nudge/Utils.swift
@@ -8,7 +8,7 @@
 import AppKit
 import Foundation
 import SystemConfiguration
-
+    
 struct Utils {
     func activateNudge() {
         print("Re-activating Nudge")
@@ -27,7 +27,7 @@ struct Utils {
     }
     
     func demoModeEnabled() -> Bool {
-        return CommandLine.arguments.contains("-demo")
+        return CommandLine.arguments.contains("-demo-mode")
     }
     
     func fullyUpdated() -> Bool {
@@ -69,10 +69,16 @@ struct Utils {
         Date()
     }
     
+    func getJSONUrl() -> String {
+        // let jsonURL = UserDefaults.standard.volatileDomain(forName: UserDefaults.argumentDomain)
+        let jsonURL = UserDefaults.standard.string(forKey: "json-url") ?? "file:///Library/Preferences/com.github.macadmins.Nudge.json" // For Greg Neagle
+        return jsonURL
+    }
+    
     func getInitialDate() -> Date {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "MM-dd-yyyy"
-        return dateFormatter.date(from: "08-06-2020") ?? Date()
+        return dateFormatter.date(from: "08-06-2020") ?? Date() // <3
     }
     
     func getMajorOSVersion() -> Int {

--- a/Nudge/nudgePrefs.swift
+++ b/Nudge/nudgePrefs.swift
@@ -10,9 +10,21 @@ import Foundation
 // TODO: use CFPreferences to get mdm/mobileconfig logic and prioritize over json
 struct nudgePrefs{
     func loadNudgePrefs() -> NudgePreferences? {
-        let local_url = Utils().getJSONUrl()
+        let url = Utils().getJSONUrl()
 
-        guard let fileURL = URL(string: local_url) else {
+        if url.contains("https://") || url.contains("http://") {
+            if let data = try? Data(contentsOf: URL(string: url)) {
+                do {
+                    let decodedData = try NudgePreferences(data: data)
+                    return decodedData
+                } catch {
+                    print(error)
+                    return nil
+                }
+            }
+        }
+
+        guard let fileURL = URL(string: url) else {
             print("Could not find on-disk json")
             return nil
         }

--- a/Nudge/nudgePrefs.swift
+++ b/Nudge/nudgePrefs.swift
@@ -13,13 +13,15 @@ struct nudgePrefs{
         let url = Utils().getJSONUrl()
 
         if url.contains("https://") || url.contains("http://") {
-            if let data = try? Data(contentsOf: URL(string: url)) {
-                do {
-                    let decodedData = try NudgePreferences(data: data)
-                    return decodedData
-                } catch {
-                    print(error)
-                    return nil
+            if let json_url = URL(string: url) {
+                if let data = try? Data(contentsOf: json_url) {
+                    do {
+                        let decodedData = try NudgePreferences(data: data)
+                        return decodedData
+                    } catch {
+                        print(error)
+                        return nil
+                    }
                 }
             }
         }

--- a/Nudge/nudgePrefs.swift
+++ b/Nudge/nudgePrefs.swift
@@ -10,8 +10,7 @@ import Foundation
 // TODO: use CFPreferences to get mdm/mobileconfig logic and prioritize over json
 struct nudgePrefs{
     func loadNudgePrefs() -> NudgePreferences? {
-        // For Greg Neagle
-        let local_url = "file:///Library/Preferences/com.github.macadmins.Nudge.json"
+        let local_url = Utils().getJSONUrl()
 
         guard let fileURL = URL(string: local_url) else {
             print("Could not find on-disk json")


### PR DESCRIPTION
You can now do something like:

`Nudge.app/Contents/MacOS/Nudge -json-url "file:///path/to/nudge.json"`

or also 

`Nudge.app/Contents/MacOS/Nudge -json-url "https://raw.githubusercontent.com/macadmins/nudge/main/Nudge/example.json"`

If you don't pass `-json-url` it will look for `/Library/Preferences/com.github.macadmins.Nudge.json`