### PR TITLE
Hide windows if over deferral count and update/fix simpleMode

### DIFF
--- a/Nudge/Nudge.swift
+++ b/Nudge/Nudge.swift
@@ -97,25 +97,16 @@ struct Nudge: View {
                 // actionButton
                 Button(action: Utils().updateDevice, label: {
                     Text(actionButtonText)
-                        .frame(minWidth: 100)
+                        .frame(minWidth: 120)
                   }
                 )
                 .keyboardShortcut(.defaultAction)
                 .padding(.vertical, 2)
-
-                // primaryQuitButton
-                Button(action: {AppKit.NSApp.terminate(nil)}, label: {
-                    Text(primaryQuitButtonText)
-                        .frame(minWidth: 100)
-                    }
-                )
-                .padding(.vertical, 2)
                 
-                // More Info
-                // https://developer.apple.com/documentation/swiftui/openurlaction
+                Spacer()
+                
+                // Bottom buttons
                 HStack {
-                    // Force the button to the right with a spacer
-                    Spacer()
                     // informationButton
                     if aboutUpdateURL != "" {
                         Button(action: Utils().openMoreInfo, label: {
@@ -124,10 +115,67 @@ struct Nudge: View {
                           }
                         )
                         .buttonStyle(BorderlessButtonStyle())
-                        .padding(.trailing, 20)
+                        .padding(.leading, 20)
+                    }
+
+                    // Separate the buttons with a spacer
+                    Spacer()
+                    
+                    if Utils().demoModeEnabled() || !pastRequiredInstallationDate && allowedDeferrals > self.deferralCountUI {
+                        // secondaryQuitButton
+                        if requireDualQuitButtons {
+                            if self.hasClickedSecondaryQuitButton {
+                                Button(action: {}, label: {
+                                    Text(secondaryQuitButtonText)
+                                  }
+                                )
+                                .hidden()
+                            } else {
+                                Button(action: {
+                                    hasClickedSecondaryQuitButton = true
+                                }, label: {
+                                    Text(secondaryQuitButtonText)
+                                  }
+                                )
+                            }
+                        } else {
+                            Button(action: {}, label: {
+                                Text(secondaryQuitButtonText)
+                              }
+                            )
+                            .hidden()
+                        }
+                    
+                        // primaryQuitButton
+                        if requireDualQuitButtons {
+                            if self.hasClickedSecondaryQuitButton {
+                                Button(action: {AppKit.NSApp.terminate(nil)}, label: {
+                                    Text(primaryQuitButtonText)
+                                        .frame(minWidth: 35)
+                                  }
+                                )
+                            } else {
+                                Button(action: {
+                                    hasClickedSecondaryQuitButton = true
+                                }, label: {
+                                    Text(primaryQuitButtonText)
+                                        .frame(minWidth: 35)
+                                  }
+                                )
+                                .hidden()
+                            }
+                        } else {
+                            Button(action: {AppKit.NSApp.terminate(nil)}, label: {
+                                Text(primaryQuitButtonText)
+                                    .frame(minWidth: 35)
+                              }
+                            )
+                        }
                     }
                 }
                 // https://www.hackingwithswift.com/books/ios-swiftui/running-code-when-our-app-launches
+                .padding(.trailing, 20)
+                .padding(.bottom, 15)
                 .onAppear(perform: nudgeStartLogic)
             }
             .frame(width: 900, height: 450)

--- a/Nudge/Nudge.swift
+++ b/Nudge/Nudge.swift
@@ -94,6 +94,21 @@ struct Nudge: View {
                 }
                 .padding(.vertical, 2)
                 
+                // Ignored Count
+                HStack{
+                    Text("Ignored Count:")
+                        .font(.title2)
+                    Text(String(self.deferralCountUI))
+                        .font(.title2)
+                        .fontWeight(.bold)
+                        .onReceive(nudgeRefreshCycleTimer) { _ in
+                            if needToActivateNudge(deferralCountVar: deferralCount, lastRefreshTimeVar: lastRefreshTime) {
+                                self.deferralCountUI += 1
+                            }
+                        }
+                }
+                .padding(.vertical, 2)
+                
                 // actionButton
                 Button(action: Utils().updateDevice, label: {
                     Text(actionButtonText)

--- a/Nudge/UILogic.swift
+++ b/Nudge/UILogic.swift
@@ -50,12 +50,12 @@ func needToActivateNudge(deferralCountVar: Int, lastRefreshTimeVar: Date) -> Boo
         return false
     }
     
-    // TODO: turn initialRefreshCycle into conditional
     if Utils().getTimerController() > timeDiff  {
         return false
     }
     
     let frontmostApplication = NSWorkspace.shared.frontmostApplication
+    let runningApplications = NSWorkspace.shared.runningApplications
     
     // Don't nudge if major upgrade is frontmostApplication
     if FileManager.default.fileExists(atPath: majorUpgradeAppPath) {
@@ -76,9 +76,23 @@ func needToActivateNudge(deferralCountVar: Int, lastRefreshTimeVar: Date) -> Boo
         _ = deferralCount += 1
         _ = lastRefreshTime = Date()
         Utils().activateNudge()
-        // TODO: Perhaps add the logic from nudge-python to hide all of the other windows
         if deferralCountVar > allowedDeferrals  {
             print("Nudge deferral count over threshold")
+            // Loop through all the running applications and hide them
+            for runningApplication in runningApplications {
+                let appName = runningApplication.bundleIdentifier ?? ""
+                let appBundle = runningApplication.bundleURL
+                if acceptableApps.contains(appName) {
+                    continue
+                }
+                if NSURL.fileURL(withPath: majorUpgradeAppPath) == appBundle {
+                    continue
+                }
+                // Taken from nudge-python as there was a race condition with NSWorkspace
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.001, execute: {
+                    runningApplication.hide()
+                })
+            }
             Utils().updateDevice()
         }
         return true

--- a/es.lproj/Localizable.strings
+++ b/es.lproj/Localizable.strings
@@ -7,3 +7,22 @@
 */
 
 "Language:" = "Idioma:";
+
+//// Additional Device Information
+"Additional Device Information" = "Información adicional del dispositivo";
+// Username
+"Username:" = "Nombre de usuario:";
+// Serial Number
+"Serial Number:" = "Número de serie:";
+// Architecture
+"Architecture:" = "Arquitectura:";
+
+//// Left side of Nudge
+// Current OS Version
+"Current OS Version:" = "Versión actual del sistema operativo:";
+// Required OS Version
+"Required OS Version:" = "Versión requerida del sistema operativo:";
+// Days remaining to update
+"Days remaining to update:" = "Días restantes para actualizar:";
+// Ignored Count
+"Ignored Count:" = "Recuento ignorado:";


### PR DESCRIPTION
This does the following:
1. fixes https://github.com/macadmins/nudge/issues/64 which adds hides all of the user's apps if they have passed the deferral count
2. Adds the `I understand` and `Later` logic into simpleMode - https://github.com/macadmins/nudge/issues/73
3. Adds the `Deferral Count` logic into simpleMode, which then triggers the refreshUI code, fixing https://github.com/macadmins/nudge/issues/78