### PR TITLE
Version info

### DIFF
--- a/Nudge/ContentView.swift
+++ b/Nudge/ContentView.swift
@@ -46,10 +46,14 @@ struct HostingWindowFinder: NSViewRepresentable {
 
     func makeNSView(context: Self.Context) -> NSView {
         let view = NSView()
+        if Utils().versionArgumentPassed() {
+            print(Utils().getNudgeVersion())
+            AppKit.NSApp.terminate(nil)
+        }
 
         if randomDelay {
             let randomDelaySeconds = Int.random(in: 1...maxRandomDelayInSeconds)
-            print("Delaying initial run by", String(randomDelaySeconds), "seconds...")
+            uiLog.info("Delaying initial run (in seconds) by: \(String(randomDelaySeconds), privacy: .public)")
             runSoftwareUpdate(delay: randomDelaySeconds)
             DispatchQueue.main.asyncAfter(deadline: .now() + Double(randomDelaySeconds)) { [weak view] in
                 self.callback(view?.window)

--- a/Nudge/Nudge.swift
+++ b/Nudge/Nudge.swift
@@ -700,6 +700,7 @@ struct deviceInfo: View {
     @State var systemConsoleUsername = Utils().getSystemConsoleUsername()
     @State var serialNumber = Utils().getSerialNumber()
     @State var cpuType = Utils().getCPUTypeString()
+    @State var nudgeVersion = Utils().getNudgeVersion()
 
     var body: some View {
         VStack {
@@ -766,10 +767,18 @@ struct deviceInfo: View {
                 Text(language)
                     .foregroundColor(.secondary)
             }
+            
+            // Nudge Version
+            HStack{
+                Text("Version:")
+                Text(self.nudgeVersion)
+                    .foregroundColor(.secondary)
+            }
+            .padding(.vertical, 1)
 
             Spacer()
         }
-        .frame(width: 350, height: 175)
+        .frame(width: 400, height: 200)
     }
 }
 

--- a/Nudge/Nudge.swift
+++ b/Nudge/Nudge.swift
@@ -21,14 +21,14 @@ struct Nudge: View {
     @State var pastRequiredInstallationDate = Utils().pastRequiredInstallationDate()
     @State var hasClickedSecondaryQuitButton = false
     @State var deferralCountUI = 0
-    
+
     // Modal view for screenshot and device info
     @State var showSSDetail = false
     @State var showDeviceInfo = false
-    
+
     // Get the screen frame
     var screen = NSScreen.main?.visibleFrame
-    
+
     // Setup the main refresh timer that controls the child refresh logic
     let nudgeRefreshCycleTimer = Timer.publish(every: Double(nudgeRefreshCycle), on: .main, in: .common).autoconnect()
 
@@ -93,7 +93,7 @@ struct Nudge: View {
                     }
                 }
                 .padding(.vertical, 2)
-                
+
                 // Ignored Count
                 HStack{
                     Text("Ignored Count:")
@@ -108,7 +108,7 @@ struct Nudge: View {
                         }
                 }
                 .padding(.vertical, 2)
-                
+
                 // actionButton
                 Button(action: Utils().updateDevice, label: {
                     Text(actionButtonText)
@@ -117,9 +117,9 @@ struct Nudge: View {
                 )
                 .keyboardShortcut(.defaultAction)
                 .padding(.vertical, 2)
-                
+
                 Spacer()
-                
+
                 // Bottom buttons
                 HStack {
                     // informationButton
@@ -143,7 +143,7 @@ struct Nudge: View {
 
                     // Separate the buttons with a spacer
                     Spacer()
-                    
+
                     if Utils().demoModeEnabled() || !pastRequiredInstallationDate && allowedDeferrals > self.deferralCountUI {
                         // secondaryQuitButton
                         if requireDualQuitButtons {
@@ -167,7 +167,7 @@ struct Nudge: View {
                             )
                             .hidden()
                         }
-                    
+
                         // primaryQuitButton
                         if requireDualQuitButtons {
                             if self.hasClickedSecondaryQuitButton {
@@ -269,8 +269,8 @@ struct Nudge: View {
                     .padding(.top, 20)
                     .padding(.bottom, 20)
                     .frame(width: 230)
-                    
-                    
+
+
                     // Can only have 10 objects per stack unless you hack it and use groups
                     Group {
                         // Required OS Version
@@ -282,7 +282,7 @@ struct Nudge: View {
                                 .foregroundColor(.secondary)
                                 .fontWeight(.bold)
                         }
-                        
+
                         // Current OS Version
                         HStack{
                             Text("Current OS Version:")
@@ -342,7 +342,7 @@ struct Nudge: View {
                                     NSCursor.pop()
                                 }
                             }
-                            
+
                         }
                         // Force the button to the left with a spacer
                         Spacer()
@@ -351,7 +351,7 @@ struct Nudge: View {
                     .padding(.bottom, 17.5)
                 }
                 .frame(width: 300, height: 450)
-                
+
                 // Vertical Line
                 VStack{
                     Rectangle()
@@ -393,7 +393,7 @@ struct Nudge: View {
                     .padding(.leading, 20.0)
                     .padding(.trailing, 20.0)
                     .frame(width: 550)
-                    
+
                     // I'm kind of impressed with myself
                     Group {
                         VStack(alignment: .leading) {
@@ -423,7 +423,7 @@ struct Nudge: View {
                             .padding(.top, 20.0)
                             .padding(.leading, 20.0)
                             .padding(.trailing, 20.0)
-                            
+
                             // Horizontal line
                             HStack{
                                 Rectangle()
@@ -434,7 +434,7 @@ struct Nudge: View {
                             .padding(.top, 10)
                             .padding(.bottom, 10)
                             .frame(width: 530)
-                            
+
                             // mainContentNote
                             HStack {
                                 Text(mainContentNote)
@@ -445,7 +445,7 @@ struct Nudge: View {
                             }
                             .padding(.leading, 20.0)
                             .padding(.trailing, 20.0)
-                            
+
                             // mainContentText
                             HStack {
                                 VStack {
@@ -551,7 +551,7 @@ struct Nudge: View {
                         HStack {
                             // Separate the buttons with a spacer
                             Spacer()
-                            
+
                             if Utils().demoModeEnabled() || !pastRequiredInstallationDate && allowedDeferrals > self.deferralCountUI {
                                 // secondaryQuitButton
                                 if requireDualQuitButtons {
@@ -575,7 +575,7 @@ struct Nudge: View {
                                     }
                                     .hidden()
                                 }
-                            
+
                                 // primaryQuitButton
                                 if requireDualQuitButtons {
                                     if self.hasClickedSecondaryQuitButton {
@@ -624,7 +624,7 @@ struct Nudge: View {
 struct screenShotZoom: View {
     @Environment(\.presentationMode) var presentationMode
     @Environment(\.colorScheme) var colorScheme
-    
+
     var body: some View {
         VStack {
             HStack {
@@ -651,7 +651,7 @@ struct screenShotZoom: View {
                 .frame(width: 35, height: 35)
                 Spacer()
             }
-        
+
             HStack {
                 Button(action: {self.presentationMode.wrappedValue.dismiss()}, label: {
                     if colorScheme == .dark && FileManager.default.fileExists(atPath: screenShotDarkPath) {
@@ -695,12 +695,12 @@ struct screenShotZoom: View {
 struct deviceInfo: View {
     @Environment(\.presentationMode) var presentationMode
     @Environment(\.colorScheme) var colorScheme
-    
+
     // State variables
     @State var systemConsoleUsername = Utils().getSystemConsoleUsername()
     @State var serialNumber = Utils().getSerialNumber()
     @State var cpuType = Utils().getCPUTypeString()
-    
+
     var body: some View {
         VStack {
             HStack {
@@ -725,10 +725,10 @@ struct deviceInfo: View {
                     }
                 }
                 .frame(width: 35, height: 35)
-                
+
                 Spacer()
             }
-            
+
             // Additional Device Information
             HStack{
                 Text("Additional Device Information")
@@ -759,14 +759,14 @@ struct deviceInfo: View {
                     .foregroundColor(.secondary)
             }
             .padding(.vertical, 1)
-            
+
             // Language
             HStack{
                 Text("Language:")
                 Text(language)
                     .foregroundColor(.secondary)
             }
-            
+
             Spacer()
         }
         .frame(width: 350, height: 175)

--- a/Nudge/OSVersion.swift
+++ b/Nudge/OSVersion.swift
@@ -5,32 +5,32 @@ public struct OSVersion {
     public var major: Int
     public var minor: Int
     public var patch: Int
-    
+
     public enum ParseError: Error {
         case badFormat(_ reason: String)
     }
-    
+
     // Creates an OSVersion by providing all the parts.
     public init(major: Int, minor: Int, patch: Int) {
         self.major = major
         self.minor = minor
         self.patch = patch
     }
-    
+
     // Creates an OSVersion by converting the built-in OperatingSystemVersion.
     public init(_ version: OperatingSystemVersion) {
         self.major = version.majorVersion
         self.minor = version.minorVersion
         self.patch = version.patchVersion
     }
-    
+
     // Creates an OSVersion by parsing a string like "11.2".
     public init(_ string: String) throws {
         let parts = string.split(separator: ".", omittingEmptySubsequences: false)
         guard parts.count == 2 || parts.count == 3 else {
             throw ParseError.badFormat("Input \(string) must have either 2 or 3 parts, got \(parts.count).")
         }
-        
+
         guard
             let major = Int(parts[0]),
             let minor = Int(parts[1]),

--- a/Nudge/PolicyManager.swift
+++ b/Nudge/PolicyManager.swift
@@ -19,11 +19,11 @@ class PolicyManager: ObservableObject {
 //    let current: OSVersion
 //    let defaults: UserDefaults
 //    let allowedVersions: [OSVersionRequirement]
-//    
+//
 //    init() throws {
 //        self.current = OSVersion(ProcessInfo().operatingSystemVersion)
 //        self.defaults = .standard
-//        
+//
 //        guard
 //            let versionsDict = defaults.object(forKey: "osVersionRequirement") as? [[String: Any]]
 //        else {
@@ -31,7 +31,7 @@ class PolicyManager: ObservableObject {
 //        }
 //        self.allowedVersions = try versionsDict.map(OSVersionRequirement.init)
 //    }
-//    
+//
 //    init(withVersion: OSVersion) {
 //        self.current = withVersion
 //        self.defaults = .standard // add something different for previews?
@@ -51,7 +51,7 @@ class PolicyManager: ObservableObject {
 //        guard let _v = self[key] else {
 //            throw DefaultsError.missingKey(key)
 //        }
-//        
+//
 //        guard let value = _v as? T else {
 //            throw DefaultsError.wrongKeyType("nudge defaults \(_v) is not \(T.self)")
 //        }

--- a/Nudge/SoftwareUpdate.swift
+++ b/Nudge/SoftwareUpdate.swift
@@ -25,15 +25,15 @@ class SoftwareUpdate {
             let msg = "Error listing software updates"
             softwareupdateListLog.error("\(msg, privacy: .public)")
         }
-        
+
         task.waitUntilExit()
-        
+
         let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
         let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
 
         let output = String(decoding: outputData, as: UTF8.self)
         let error = String(decoding: errorData, as: UTF8.self)
-        
+
         if task.terminationStatus != 0 {
             softwareupdateListLog.error("Error listing software updates: \(error, privacy: .public)")
             return error
@@ -41,11 +41,11 @@ class SoftwareUpdate {
             softwareupdateListLog.info("\(output, privacy: .public)")
             return output
         }
-        
+
     }
-    
+
     func Download() {
-        
+
         softwareupdateDownloadLog.info("enforceMinorUpdates: \(enforceMinorUpdates, privacy: .public)")
 
         if Utils().getCPUTypeString() == "Apple Silicon" {
@@ -53,9 +53,9 @@ class SoftwareUpdate {
             softwareupdateListLog.info("\(msg, privacy: .public)")
             return
         }
-        
+
         let softwareupdateList = self.List()
-        
+
         if softwareupdateList.contains("restart") {
             let msg = "Starting softwareupdate download"
             softwareupdateListLog.info("\(msg, privacy: .public)")

--- a/Nudge/UILogic.swift
+++ b/Nudge/UILogic.swift
@@ -54,7 +54,7 @@ func needToActivateNudge(deferralCountVar: Int, lastRefreshTimeVar: Date) -> Boo
     if noTimers {
         return false
     }
-    
+
     let currentTime = Date().timeIntervalSince1970
     let timeDiff = Int((currentTime - lastRefreshTimeVar.timeIntervalSince1970))
 
@@ -66,14 +66,14 @@ func needToActivateNudge(deferralCountVar: Int, lastRefreshTimeVar: Date) -> Boo
         _ = lastRefreshTime = Date()
         return false
     }
-    
+
     if Utils().getTimerController() > timeDiff  {
         return false
     }
-    
+
     let frontmostApplication = NSWorkspace.shared.frontmostApplication
     let runningApplications = NSWorkspace.shared.runningApplications
-    
+
     // Don't nudge if major upgrade is frontmostApplication
     if FileManager.default.fileExists(atPath: majorUpgradeAppPath) {
         if NSURL.fileURL(withPath: majorUpgradeAppPath) == frontmostApplication?.bundleURL {
@@ -82,14 +82,14 @@ func needToActivateNudge(deferralCountVar: Int, lastRefreshTimeVar: Date) -> Boo
             return false
         }
     }
-    
+
     // Don't nudge if acceptable apps are frontmostApplication
     if acceptableApps.contains((frontmostApplication?.bundleIdentifier!)!) {
         let msg = "acceptableApp is currently the frontmostApplication"
         uiLog.info("\(msg, privacy: .public)")
         return false
     }
-    
+
     // If we get here, Nudge if not frontmostApplication
     if !NSApplication.shared.isActive {
         _ = deferralCount += 1

--- a/Nudge/Utils.swift
+++ b/Nudge/Utils.swift
@@ -132,6 +132,19 @@ struct Utils {
         utilsLog.info("Minor OS Version: \(MinorOSVersion, privacy: .public)")
         return MinorOSVersion
     }
+    
+    func getNudgeVersion() -> String {
+        return Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0"
+    }
+    
+    func versionArgumentPassed() -> Bool {
+        let versionArgumentPassed = CommandLine.arguments.contains("-version")
+        if versionArgumentPassed {
+            let msg = "-version argument passed"
+            uiLog.info("\(msg, privacy: .public)")
+        }
+        return versionArgumentPassed
+    }
 
     func getNumberOfDaysBetween() -> Int {
        let currentCal = Calendar.current

--- a/Nudge/Utils.swift
+++ b/Nudge/Utils.swift
@@ -22,14 +22,14 @@ struct Utils {
         NSApp.activate(ignoringOtherApps: true)
         NSApp.mainWindow?.makeKeyAndOrderFront(self)
     }
-    
+
     func createImageData(fileImagePath: String) -> NSImage {
         utilsLog.info("Creating image path for \(fileImagePath, privacy: .public)")
         let urlPath = NSURL(fileURLWithPath: fileImagePath)
         let imageData:NSData = NSData(contentsOf: urlPath as URL)!
         return NSImage(data: imageData as Data)!
     }
-    
+
     func demoModeEnabled() -> Bool {
         let demoModeArgumentPassed = CommandLine.arguments.contains("-demo-mode")
         if demoModeArgumentPassed {
@@ -38,7 +38,7 @@ struct Utils {
         }
         return demoModeArgumentPassed
     }
-    
+
     func exitNudge() {
         let msg = "User clicked primaryQuitButton"
         uiLog.info("\(msg, privacy: .public)")
@@ -53,7 +53,7 @@ struct Utils {
         }
         return forceScreenShotIconMode
     }
-    
+
     func fullyUpdated() -> Bool {
         let fullyUpdated = versionGreaterThanOrEqual(current_version: OSVersion(ProcessInfo().operatingSystemVersion).description, new_version: requiredMinimumOSVersion)
         utilsLog.info("Device is fully updated: \(fullyUpdated, privacy: .public)")
@@ -80,7 +80,7 @@ struct Utils {
         if type == -1 {
             return "error in CPU type"
         }
-        
+
         let cpu_arch = type & 0xff // mask for architecture bits
         if cpu_arch == cpu_type_t(7){
             let msg = "CPU Type is Intel"
@@ -96,37 +96,37 @@ struct Utils {
         utilsLog.info("\(msg, privacy: .public)")
         return "unknown"
     }
-    
+
     func getCurrentDate() -> Date {
         Date()
     }
-    
+
     func getJSONUrl() -> String {
         // let jsonURL = UserDefaults.standard.volatileDomain(forName: UserDefaults.argumentDomain)
         let jsonURL = UserDefaults.standard.string(forKey: "json-url") ?? "file:///Library/Preferences/com.github.macadmins.Nudge.json" // For Greg Neagle
         utilsLog.info("JSON url: \(jsonURL, privacy: .public)")
         return jsonURL
     }
-    
+
     func getInitialDate() -> Date {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "MM-dd-yyyy"
         return dateFormatter.date(from: "08-06-2020") ?? Date() // <3
     }
-    
+
     func getMajorOSVersion() -> Int {
         let MajorOSVersion = ProcessInfo().operatingSystemVersion.majorVersion
         utilsLog.info("OS Version: \(MajorOSVersion, privacy: .public)")
         return MajorOSVersion
     }
-    
+
     func getMajorRequiredNudgeOSVersion() -> Int {
         let parts = requiredMinimumOSVersion.split(separator: ".", omittingEmptySubsequences: false)
         let majorRequiredNudgeOSVersion = Int((parts[0]))!
         utilsLog.info("Major required OS version: \(majorRequiredNudgeOSVersion, privacy: .public)")
         return majorRequiredNudgeOSVersion
     }
-    
+
     func getMinorOSVersion() -> Int {
         let MinorOSVersion = ProcessInfo().operatingSystemVersion.minorVersion
         utilsLog.info("Minor OS Version: \(MinorOSVersion, privacy: .public)")
@@ -144,13 +144,13 @@ struct Utils {
     func getNumberOfHoursBetween() -> Int {
         return Int(requiredInstallationDate.timeIntervalSince(getCurrentDate()) / 3600 )
     }
-    
+
     func getPatchOSVersion() -> Int {
         let PatchOSVersion = ProcessInfo().operatingSystemVersion.patchVersion
         utilsLog.info("Patch OS Version: \(PatchOSVersion, privacy: .public)")
         return PatchOSVersion
     }
-    
+
     func getSerialNumber() -> String {
         if Utils().demoModeEnabled() {
                 return "C00000000000"
@@ -158,24 +158,24 @@ struct Utils {
         // https://ourcodeworld.com/articles/read/1113/how-to-retrieve-the-serial-number-of-a-mac-with-swift
         var serialNumber: String? {
             let platformExpert = IOServiceGetMatchingService(kIOMasterPortDefault, IOServiceMatching("IOPlatformExpertDevice") )
-            
+
             guard platformExpert > 0 else {
                 return nil
             }
-            
+
             guard let serialNumber = (IORegistryEntryCreateCFProperty(platformExpert, kIOPlatformSerialNumberKey as CFString, kCFAllocatorDefault, 0).takeUnretainedValue() as? String)?.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) else {
                 return nil
             }
-            
+
             IOObjectRelease(platformExpert)
 
             utilsLog.info("Serial Number: \(serialNumber, privacy: .public)")
             return serialNumber
         }
-        
+
         return serialNumber ?? ""
     }
-    
+
     func getSystemConsoleUsername() -> String {
         // https://gist.github.com/joncardasis/2c46c062f8450b96bb1e571950b26bf7
         var uid: uid_t = 0
@@ -184,14 +184,14 @@ struct Utils {
         utilsLog.info("System console username: \(SystemConsoleUsername, privacy: .public)")
         return SystemConsoleUsername
     }
-    
+
     func getTimerController() -> Int {
         let timerCycle = getTimerControllerInt()
         // print("Timer Cycle:", String(timerCycle)) // Easy way to debug the timerController logic
         utilsLog.info("Timer cycle: \(timerCycle, privacy: .public)")
         return timerCycle
     }
-    
+
     func getTimerControllerInt() -> Int {
         if 0 >= getNumberOfHoursBetween() {
             return elapsedRefreshCycle
@@ -212,13 +212,13 @@ struct Utils {
         uiLog.info("\(msg, privacy: .public)")
         NSWorkspace.shared.open(url)
     }
-    
+
     func pastRequiredInstallationDate() -> Bool {
         let pastRequiredInstallationDate = getCurrentDate() > requiredInstallationDate
         utilsLog.info("Device pastRequiredInstallationDate: \(pastRequiredInstallationDate, privacy: .public)")
         return pastRequiredInstallationDate
     }
-    
+
     func requireDualQuitButtons() -> Bool {
         let requireDualQuitButtons = (approachingWindowTime / 24) >= getNumberOfDaysBetween()
         uiLog.info("Device requireDualQuitButtons: \(requireDualQuitButtons, privacy: .public)")
@@ -235,7 +235,7 @@ struct Utils {
         utilsLog.info("Device requireMajorUpgrade: \(requireMajorUpdate, privacy: .public)")
         return requireMajorUpdate
     }
-    
+
     func simpleModeEnabled() -> Bool {
         let simpleModeEnabled = CommandLine.arguments.contains("-simple-mode")
         if simpleModeEnabled {

--- a/Nudge/nudgePrefs.swift
+++ b/Nudge/nudgePrefs.swift
@@ -31,11 +31,11 @@ struct nudgePrefs{
             prefsLog.error("\(msg, privacy: .public)")
             return nil
         }
-        
+
         if Utils().demoModeEnabled() {
             return nil
         }
-        
+
         if FileManager.default.fileExists(atPath: fileURL.path) {
             do {
                 let content = try Data(contentsOf: fileURL)

--- a/NudgeTests/OSVersionTests.swift
+++ b/NudgeTests/OSVersionTests.swift
@@ -9,7 +9,6 @@ import Foundation
 import XCTest
 @testable import Nudge
 
-
 class OSVersionTest: XCTestCase {
     func testCompare() {
         let a = OSVersion(major: 11, minor: 2, patch: 0)
@@ -17,21 +16,20 @@ class OSVersionTest: XCTestCase {
         let c = OSVersion(major: 11, minor: 3, patch: 0)
         let d = OSVersion(major: 10, minor: 15, patch: 9999)
 
-        
         XCTAssertEqual(a,b)
         XCTAssertNotEqual(a,c)
         XCTAssertGreaterThan(c,b)
         XCTAssertGreaterThanOrEqual(c,d)
         XCTAssertFalse(a < d, "BigSur is newer than Catalina")
     }
-    
+
     func testParse() {
         let expected = OSVersion(major: 11, minor: 5, patch: 0)
         guard let actual = try? OSVersion("11.5") else {
             XCTFail("expected OSVersion to not fail parsing '11.5'")
             return
         }
-        
+
         XCTAssertEqual(expected, actual)
     }
 }

--- a/de.lproj/Localizable.strings
+++ b/de.lproj/Localizable.strings
@@ -16,6 +16,8 @@
 "Serial Number:" = "Seriennummer:";
 // Architecture
 "Architecture:" = "Architektur:";
+// Nudge Version
+"Version:" = "Ausführung:";
 
 //// Left side of Nudge
 // Current OS Version

--- a/en.lproj/Localizable.strings
+++ b/en.lproj/Localizable.strings
@@ -16,6 +16,8 @@
 "Serial Number:" = "Serial Number:";
 // Architecture
 "Architecture:" = "Architecture:";
+// Nudge Version
+"Version:" = "Version:";
 
 //// Left side of Nudge
 // Current OS Version

--- a/es.lproj/Localizable.strings
+++ b/es.lproj/Localizable.strings
@@ -16,6 +16,8 @@
 "Serial Number:" = "Número de serie:";
 // Architecture
 "Architecture:" = "Arquitectura:";
+// Nudge Version
+"Version:" = "Versión:";
 
 //// Left side of Nudge
 // Current OS Version

--- a/fr.lproj/Localizable.strings
+++ b/fr.lproj/Localizable.strings
@@ -16,6 +16,8 @@
 "Serial Number:" = "Numéro de série:";
 // Architecture
 "Architecture:" = "Architecture:";
+// Nudge Version
+"Version:" = "Version:";
 
 //// Left side of Nudge
 // Current OS Version


### PR DESCRIPTION
adds a new `-version` flag and also new UI for it

<img width="1012" alt="Screen Shot 2021-02-16 at 2 59 13 PM" src="https://user-images.githubusercontent.com/5685016/108120897-92193500-7067-11eb-8d83-596210a22e2e.png">

```
Nudge.app/Contents/MacOS/Nudge -version
0.0.2
