### PR TITLE
Center Nudge every time the primaryRefreshCycle is triggered

### DIFF
--- a/Nudge/Utilities/UILogic.swift
+++ b/Nudge/Utilities/UILogic.swift
@@ -48,6 +48,9 @@ func userHasClickedSecondaryQuitButton() {
 }
 
 func needToActivateNudge(deferralCountVar: Int, lastRefreshTimeVar: Date) -> Bool {
+    // Center Nudge
+    Utils().centerNudge()
+
     // If noTimers is true, just bail
     if noTimers {
         return false

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -15,9 +15,14 @@ struct Utils {
         utilsLog.info("\(msg, privacy: .public)")
         // NSApp.windows[0] is only safe because we have a single window. Should we increase windows, this will be a problem.
         // Sheets do not count as windows though.
-        NSApp.windows[0].center()
         NSApp.activate(ignoringOtherApps: true)
         NSApp.windows[0].makeKeyAndOrderFront(self)
+    }
+
+    func centerNudge() {
+        // NSApp.windows[0] is only safe because we have a single window. Should we increase windows, this will be a problem.
+        // Sheets do not count as windows though.
+        NSApp.windows[0].center()
     }
 
     func createImageData(fileImagePath: String) -> NSImage {


### PR DESCRIPTION
I realized https://github.com/macadmins/nudge/issues/121 would be ineffective as designed unless you had a very short timerController set. This will ensure every 60 seconds (by default) that it will re-center.