### PR TITLE
Tweak logging

### DIFF
--- a/Nudge/UI/ContentView.swift
+++ b/Nudge/UI/ContentView.swift
@@ -57,7 +57,7 @@ struct HostingWindowFinder: NSViewRepresentable {
 
         if randomDelay {
             let randomDelaySeconds = Int.random(in: 1...maxRandomDelayInSeconds)
-            uiLog.info("Delaying initial run (in seconds) by: \(String(randomDelaySeconds), privacy: .public)")
+            uiLog.debug("Delaying initial run (in seconds) by: \(String(randomDelaySeconds), privacy: .public)")
             runSoftwareUpdate(delay: randomDelaySeconds)
             DispatchQueue.main.asyncAfter(deadline: .now() + Double(randomDelaySeconds)) { [weak view] in
                 self.callback(view?.window)

--- a/Nudge/UI/StandardMode/LeftSide.swift
+++ b/Nudge/UI/StandardMode/LeftSide.swift
@@ -32,6 +32,7 @@ struct StandardModeLeftSide: View {
         VStack(alignment: .center, spacing: 20) {
             HStack {
                 Button(action: {
+                    Utils().userInitiatedDeviceInfo()
                     self.showDeviceInfo.toggle()
                 }) {
                     Image(systemName: "questionmark.circle")

--- a/Nudge/Utilities/Logger.swift
+++ b/Nudge/Utilities/Logger.swift
@@ -20,6 +20,6 @@ let softwareupdateDownloadLog = Logger(subsystem: bundleID, category: "softwareu
 class NudgeLogger {
     init() {
         let msg = "Starting log events"
-        loggingLog.info("\(msg, privacy: .public)")
+        loggingLog.debug("\(msg, privacy: .public)")
     }
 }

--- a/Nudge/Utilities/Preferences.swift
+++ b/Nudge/Utilities/Preferences.swift
@@ -70,7 +70,7 @@ func getOSVersionRequirementsProfile() -> OSVersionRequirement? {
         }
     } else {
         let msg = "profile osVersionRequirements key is empty"
-        prefsLog.info("\(msg, privacy: .public)")
+        prefsLog.debug("\(msg, privacy: .public)")
     }
     return nil
 }
@@ -87,7 +87,7 @@ func getOSVersionRequirementsJSON() -> OSVersionRequirement? {
         }
     } else {
         let msg = "json osVersionRequirements key is empty"
-        prefsLog.info("\(msg, privacy: .public)")
+        prefsLog.debug("\(msg, privacy: .public)")
     }
     return nil
 }

--- a/Nudge/Utilities/SoftwareUpdate.swift
+++ b/Nudge/Utilities/SoftwareUpdate.swift
@@ -49,7 +49,7 @@ class SoftwareUpdate {
 
         if Utils().getCPUTypeString() == "Apple Silicon" {
             let msg = "Apple Silicon devices do not support automated softwareupdate calls. Please use MDM."
-            softwareupdateListLog.info("\(msg, privacy: .public)")
+            softwareupdateListLog.warning("\(msg, privacy: .public)")
             return
         }
 
@@ -57,7 +57,7 @@ class SoftwareUpdate {
 
         if softwareupdateList.contains("restart") {
             let msg = "Starting softwareupdate download"
-            softwareupdateListLog.info("\(msg, privacy: .public)")
+            softwareupdateListLog.debug("\(msg, privacy: .public)")
             let task = Process()
             task.launchPath = "/usr/sbin/softwareupdate"
             task.arguments = ["--download", "--all"]
@@ -81,7 +81,7 @@ class SoftwareUpdate {
             let output = String(decoding: outputData, as: UTF8.self)
             let error = String(decoding: errorData, as: UTF8.self)
 
-            softwareupdateDownloadLog.info("\(output, privacy: .public)")
+            softwareupdateDownloadLog.debug("\(output, privacy: .public)")
             softwareupdateDownloadLog.error("\(error, privacy: .public)")
         } else {
             let msg = "softwareupdate did not find any available updates"

--- a/Nudge/Utilities/UILogic.swift
+++ b/Nudge/Utilities/UILogic.swift
@@ -19,14 +19,14 @@ func nudgeStartLogic() {
         } else {
             if Utils().demoModeEnabled() {
                 let msg = "Device in demo mode"
-                uiLog.info("\(msg, privacy: .public)")
+                uiLog.debug("\(msg, privacy: .public)")
                 if Utils().simpleModeEnabled() {
                     let msg = "Device in simple mode"
-                    uiLog.info("\(msg, privacy: .public)")
+                    uiLog.debug("\(msg, privacy: .public)")
                 }
             } else {
                 let msg = "Device in fully updated"
-                uiLog.info("\(msg, privacy: .public)")
+                uiLog.debug("\(msg, privacy: .public)")
                 Utils().exitNudge()
             }
         }
@@ -64,7 +64,7 @@ func needToActivateNudge(deferralCountVar: Int, lastRefreshTimeVar: Date) -> Boo
     // The first time the main timer contoller hits we don't care
     if !afterFirstRun {
         let msg = "Initilizing nudgeRefreshCycle"
-        uiLog.info("\(msg, privacy: .public)")
+        uiLog.debug("\(msg, privacy: .public)")
         _ = afterFirstRun = true
         _ = lastRefreshTime = Date()
         return false

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -38,7 +38,7 @@ struct Utils {
     }
 
     func createImageData(fileImagePath: String) -> NSImage {
-        utilsLog.info("Creating image path for \(fileImagePath, privacy: .public)")
+        utilsLog.debug("Creating image path for \(fileImagePath, privacy: .public)")
         let urlPath = NSURL(fileURLWithPath: fileImagePath)
         let imageData:NSData = NSData(contentsOf: urlPath as URL)!
         return NSImage(data: imageData as Data)!
@@ -64,7 +64,7 @@ struct Utils {
         let forceScreenShotIconMode = CommandLine.arguments.contains("-force-screenshot-icon")
         if forceScreenShotIconMode {
             let msg = "-force-screenshot-icon argument passed"
-            uiLog.info("\(msg, privacy: .public)")
+            uiLog.debug("\(msg, privacy: .public)")
         }
         return forceScreenShotIconMode
     }
@@ -74,7 +74,7 @@ struct Utils {
         let fullyUpdated = versionGreaterThanOrEqual(currentVersion: currentVersion, newVersion: requiredMinimumOSVersion)
         if fullyUpdated {
             let msg = "Current operating system (\(currentVersion)) is greater than or equal to required operating system (\(requiredMinimumOSVersion))"
-            utilsLog.info("\(msg, privacy: .public)")
+            utilsLog.debug("\(msg, privacy: .public)")
             return true
         } else {
             return false
@@ -113,12 +113,12 @@ struct Utils {
         let cpu_arch = type & 0xff // mask for architecture bits
         if cpu_arch == cpu_type_t(7){
             let msg = "CPU Type is Intel"
-            utilsLog.info("\(msg, privacy: .public)")
+            utilsLog.debug("\(msg, privacy: .public)")
             return "Intel"
         }
         if cpu_arch == cpu_type_t(12){
             let msg = "CPU Type is Apple Silicon"
-            utilsLog.info("\(msg, privacy: .public)")
+            utilsLog.debug("\(msg, privacy: .public)")
             return "Apple Silicon"
         }
         let msg = "Unknown CPU Type"
@@ -132,7 +132,7 @@ struct Utils {
 
     func getJSONUrl() -> String {
         let jsonURL = nudgeDefaults.string(forKey: "json-url") ?? "file:///Library/Preferences/com.github.macadmins.Nudge.json" // For Greg Neagle
-        utilsLog.info("JSON url: \(jsonURL, privacy: .public)")
+        utilsLog.debug("JSON url: \(jsonURL, privacy: .public)")
         return jsonURL
     }
 
@@ -144,20 +144,20 @@ struct Utils {
 
     func getMajorOSVersion() -> Int {
         let MajorOSVersion = ProcessInfo().operatingSystemVersion.majorVersion
-        utilsLog.info("OS Version: \(MajorOSVersion, privacy: .public)")
+        utilsLog.debug("OS Version: \(MajorOSVersion, privacy: .public)")
         return MajorOSVersion
     }
 
     func getMajorRequiredNudgeOSVersion() -> Int {
         let parts = requiredMinimumOSVersion.split(separator: ".", omittingEmptySubsequences: false)
         let majorRequiredNudgeOSVersion = Int((parts[0]))!
-        utilsLog.info("Major required OS version: \(majorRequiredNudgeOSVersion, privacy: .public)")
+        utilsLog.debug("Major required OS version: \(majorRequiredNudgeOSVersion, privacy: .public)")
         return majorRequiredNudgeOSVersion
     }
-
+s
     func getMinorOSVersion() -> Int {
         let MinorOSVersion = ProcessInfo().operatingSystemVersion.minorVersion
-        utilsLog.info("Minor OS Version: \(MinorOSVersion, privacy: .public)")
+        utilsLog.debug("Minor OS Version: \(MinorOSVersion, privacy: .public)")
         return MinorOSVersion
     }
 
@@ -220,7 +220,7 @@ struct Utils {
 
     func getPatchOSVersion() -> Int {
         let PatchOSVersion = ProcessInfo().operatingSystemVersion.patchVersion
-        utilsLog.info("Patch OS Version: \(PatchOSVersion, privacy: .public)")
+        utilsLog.debug("Patch OS Version: \(PatchOSVersion, privacy: .public)")
         return PatchOSVersion
     }
     
@@ -250,10 +250,10 @@ struct Utils {
 
             IOObjectRelease(platformExpert)
 
-            utilsLog.info("Serial Number: \(serialNumber, privacy: .public)")
+            utilsLog.debug("Serial Number: \(serialNumber, privacy: .public)")
             return serialNumber
         }
-
+s
         return serialNumber ?? ""
     }
 
@@ -262,14 +262,13 @@ struct Utils {
         var uid: uid_t = 0
         var gid: gid_t = 0
         let SystemConsoleUsername = SCDynamicStoreCopyConsoleUser(nil, &uid, &gid) as String? ?? ""
-        utilsLog.info("System console username: \(SystemConsoleUsername, privacy: .public)")
+        utilsLog.debug("System console username: \(SystemConsoleUsername, privacy: .public)")
         return SystemConsoleUsername
     }
-
+s
     func getTimerController() -> Int {
         let timerCycle = getTimerControllerInt()
-        // print("Timer Cycle:", String(timerCycle)) // Easy way to debug the timerController logic
-        utilsLog.info("Timer cycle: \(timerCycle, privacy: .public)")
+        utilsLog.debug("Timer cycle: \(timerCycle, privacy: .public)")
         return timerCycle
     }
 
@@ -302,14 +301,14 @@ struct Utils {
 
     func requireDualQuitButtons() -> Bool {
         let requireDualQuitButtons = (approachingWindowTime / 24) >= getNumberOfDaysBetween()
-        uiLog.info("Device requireDualQuitButtons: \(requireDualQuitButtons, privacy: .public)")
+        uiLog.debug("Device requireDualQuitButtons: \(requireDualQuitButtons, privacy: .public)")
         return requireDualQuitButtons
     }
 
     func requireMajorUpgrade() -> Bool {
         if requiredMinimumOSVersion == "0.0" {
             let msg = "Device requireMajorUpgrade: false"
-            utilsLog.info("\(msg, privacy: .public)")
+            utilsLog.debug("\(msg, privacy: .public)")
             return false
         }
         let requireMajorUpdate = versionGreaterThanOrEqual(currentVersion: OSVersion(ProcessInfo().operatingSystemVersion).description, newVersion: requiredMinimumOSVersion)
@@ -321,7 +320,7 @@ struct Utils {
         let simpleModeEnabled = CommandLine.arguments.contains("-simple-mode")
         if simpleModeEnabled {
             let msg = "-simple-mode argument passed"
-            uiLog.info("\(msg, privacy: .public)")
+            uiLog.debug("\(msg, privacy: .public)")
         }
         return simpleModeEnabled
     }
@@ -346,7 +345,7 @@ struct Utils {
         let versionArgumentPassed = CommandLine.arguments.contains("-version")
         if versionArgumentPassed {
             let msg = "-version argument passed"
-            uiLog.info("\(msg, privacy: .public)")
+            uiLog.debug("\(msg, privacy: .public)")
         }
         return versionArgumentPassed
     }

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -74,7 +74,7 @@ struct Utils {
         let fullyUpdated = versionGreaterThanOrEqual(currentVersion: currentVersion, newVersion: requiredMinimumOSVersion)
         if fullyUpdated {
             let msg = "Current operating system (\(currentVersion)) is greater than or equal to required operating system (\(requiredMinimumOSVersion))"
-            utilsLog.debug("\(msg, privacy: .public)")
+            utilsLog.info("\(msg, privacy: .public)")
             return true
         } else {
             return false

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -154,7 +154,7 @@ struct Utils {
         utilsLog.debug("Major required OS version: \(majorRequiredNudgeOSVersion, privacy: .public)")
         return majorRequiredNudgeOSVersion
     }
-s
+
     func getMinorOSVersion() -> Int {
         let MinorOSVersion = ProcessInfo().operatingSystemVersion.minorVersion
         utilsLog.debug("Minor OS Version: \(MinorOSVersion, privacy: .public)")
@@ -253,7 +253,7 @@ s
             utilsLog.debug("Serial Number: \(serialNumber, privacy: .public)")
             return serialNumber
         }
-s
+
         return serialNumber ?? ""
     }
 
@@ -265,7 +265,7 @@ s
         utilsLog.debug("System console username: \(SystemConsoleUsername, privacy: .public)")
         return SystemConsoleUsername
     }
-s
+
     func getTimerController() -> Int {
         let timerCycle = getTimerControllerInt()
         utilsLog.debug("Timer cycle: \(timerCycle, privacy: .public)")
@@ -326,6 +326,8 @@ s
     }
 
     func updateDevice() {
+        let msg = "User clicked updateDevice"
+        utilsLog.info("\(msg, privacy: .public)")
         if requireMajorUpgrade() {
             NSWorkspace.shared.open(URL(fileURLWithPath: majorUpgradeAppPath))
         } else {
@@ -339,6 +341,11 @@ s
         uiLog.info("\(msg, privacy: .public)")
         shouldExit = true
         AppKit.NSApp.terminate(nil)
+    }
+
+    func userInitiatedDeviceInfo() {
+        let msg = "User clicked deviceInfo"
+        uiLog.info("\(msg, privacy: .public)")
     }
 
     func versionArgumentPassed() -> Bool {


### PR DESCRIPTION
This does two major things:

- Tweaks logging levels to make more things debug/warning instead of info
- Adds logging for device info clicks

Here is the output of a run in normal mode where I click every available button:
``` 
log stream --predicate 'subsystem == "com.github.macadmins.Nudge"' --info --style syslog --color none

2021-02-25 13:03:59.752212-0500  localhost Nudge[62232]: [com.github.macadmins.Nudge:softwareupdate-download] enforceMinorUpdates: true
2021-02-25 13:03:59.752391-0500  localhost Nudge[62232]: [com.github.macadmins.Nudge:softwareupdate-list] Apple Silicon devices do not support automated softwareupdate calls. Please use MDM.
2021-02-25 13:03:59.752847-0500  localhost Nudge[62232]: [com.github.macadmins.Nudge:utilities] Device pastRequiredInstallationDate: false
2021-02-25 13:04:03.198121-0500  localhost Nudge[62232]: [com.github.macadmins.Nudge:utilities] User clicked updateDevice
2021-02-25 13:04:03.198262-0500  localhost Nudge[62232]: [com.github.macadmins.Nudge:utilities] Device requireMajorUpgrade: false
2021-02-25 13:04:07.669944-0500  localhost Nudge[62232]: [com.github.macadmins.Nudge:user-interface] User clicked deviceInfo
2021-02-25 13:04:10.741973-0500  localhost Nudge[62232]: [com.github.macadmins.Nudge:user-interface] User clicked secondaryQuitButton
2021-02-25 13:04:11.759507-0500  localhost Nudge[62232]: [com.github.macadmins.Nudge:user-interface] User clicked primaryQuitButton
```