### PR TITLE
Move HostingWindowFinder to background

### DIFF
--- a/Nudge/UI/ContentView.swift
+++ b/Nudge/UI/ContentView.swift
@@ -13,18 +13,28 @@ import SwiftUI
 struct ContentView: View {
     @EnvironmentObject var manager: PolicyManager
     var body: some View {
-        HostingWindowFinder {window in
-            window?.standardWindowButton(.closeButton)?.isHidden = true //hides the red close button
-            window?.standardWindowButton(.miniaturizeButton)?.isHidden = true //hides the yellow miniaturize button
-            window?.standardWindowButton(.zoomButton)?.isHidden = true //this removes the green zoom button
-            window?.center() // center
-            window?.isMovable = false // not movable
-            NSApp.activate(ignoringOtherApps: true) // bring to forefront upon launch
-        }
         if simpleMode() {
-            SimpleMode()
+            SimpleMode().background(
+                HostingWindowFinder {window in
+                    window?.standardWindowButton(.closeButton)?.isHidden = true //hides the red close button
+                    window?.standardWindowButton(.miniaturizeButton)?.isHidden = true //hides the yellow miniaturize button
+                    window?.standardWindowButton(.zoomButton)?.isHidden = true //this removes the green zoom button
+                    window?.center() // center
+                    window?.isMovable = false // not movable
+                    NSApp.activate(ignoringOtherApps: true) // bring to forefront upon launch
+                }
+            )
         } else {
-            StandardMode()
+            StandardMode().background(
+                HostingWindowFinder {window in
+                    window?.standardWindowButton(.closeButton)?.isHidden = true //hides the red close button
+                    window?.standardWindowButton(.miniaturizeButton)?.isHidden = true //hides the yellow miniaturize button
+                    window?.standardWindowButton(.zoomButton)?.isHidden = true //this removes the green zoom button
+                    window?.center() // center
+                    window?.isMovable = false // not movable
+                    NSApp.activate(ignoringOtherApps: true) // bring to forefront upon launch
+                }
+            )
         }
     }
 }
@@ -32,6 +42,9 @@ struct ContentView: View {
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
         ContentView().environmentObject(PolicyManager(withVersion:  try! OSVersion("11.2") ))
+            .preferredColorScheme(.light)
+        ContentView().environmentObject(PolicyManager(withVersion:  try! OSVersion("11.2") ))
+            .preferredColorScheme(.dark)
     }
 }
 

--- a/Nudge/UI/ContentView.swift
+++ b/Nudge/UI/ContentView.swift
@@ -12,8 +12,9 @@ import SwiftUI
 
 struct ContentView: View {
     @EnvironmentObject var manager: PolicyManager
+    @State var simpleModePreview: Bool
     var body: some View {
-        if simpleMode() {
+        if simpleMode() || simpleModePreview {
             SimpleMode().background(
                 HostingWindowFinder {window in
                     window?.standardWindowButton(.closeButton)?.isHidden = true //hides the red close button
@@ -39,14 +40,20 @@ struct ContentView: View {
     }
 }
 
+#if DEBUG
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        ContentView().environmentObject(PolicyManager(withVersion:  try! OSVersion("11.2") ))
+        ContentView(simpleModePreview: true).environmentObject(PolicyManager(withVersion:  try! OSVersion("11.2")))
             .preferredColorScheme(.light)
-        ContentView().environmentObject(PolicyManager(withVersion:  try! OSVersion("11.2") ))
+        ContentView(simpleModePreview: false).environmentObject(PolicyManager(withVersion:  try! OSVersion("11.2")))
+            .preferredColorScheme(.light)
+        ContentView(simpleModePreview: true).environmentObject(PolicyManager(withVersion:  try! OSVersion("11.2")))
+            .preferredColorScheme(.dark)
+        ContentView(simpleModePreview: false).environmentObject(PolicyManager(withVersion:  try! OSVersion("11.2")))
             .preferredColorScheme(.dark)
     }
 }
+#endif
 
 struct HostingWindowFinder: NSViewRepresentable {
     var callback: (NSWindow?) -> ()

--- a/Nudge/UI/Main.swift
+++ b/Nudge/UI/Main.swift
@@ -50,6 +50,19 @@ struct Main: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     let manager = try! PolicyManager() // TODO: handle errors
     var body: some Scene {
+        #if DEBUG
+        WindowGroup {
+            TabView {
+                ContentView(simpleModePreview: false).environmentObject(manager)
+                    .frame(width: 900, height: 450)
+                ContentView(simpleModePreview: true).environmentObject(manager)
+                    .frame(width: 900, height: 450)
+            }
+        }
+        // Hide Title Bar
+        .windowStyle(HiddenTitleBarWindowStyle())
+        #endif
+
         WindowGroup {
             ContentView(simpleModePreview: false).environmentObject(manager)
                 .frame(width: 900, height: 450)

--- a/Nudge/UI/Main.swift
+++ b/Nudge/UI/Main.swift
@@ -51,7 +51,7 @@ struct Main: App {
     let manager = try! PolicyManager() // TODO: handle errors
     var body: some Scene {
         WindowGroup {
-            ContentView().environmentObject(manager)
+            ContentView(simpleModePreview: false).environmentObject(manager)
                 .frame(width: 900, height: 450)
         }
         // Hide Title Bar

--- a/Nudge/UI/SimpleMode/SimpleMode.swift
+++ b/Nudge/UI/SimpleMode/SimpleMode.swift
@@ -120,6 +120,15 @@ struct SimpleMode: View {
 
                 // Separate the buttons with a spacer
                 Spacer()
+                
+                #if DEBUG
+                Button {
+                    Utils().userInitiatedExit()
+                } label: {
+                    Text(primaryQuitButtonText)
+                        .frame(minWidth: 35)
+                }
+                #endif
 
                 if Utils().demoModeEnabled() || !pastRequiredInstallationDate && allowedDeferrals > self.deferralCountUI {
                     // secondaryQuitButton
@@ -188,11 +197,11 @@ struct SimpleModePreviews: PreviewProvider {
     static var previews: some View {
         Group {
             ForEach(["en", "es", "fr"], id: \.self) { id in
-                SimpleMode().environmentObject(PolicyManager(withVersion:  try! OSVersion("11.2") ))
+                SimpleMode().environmentObject(PolicyManager(withVersion:  try! OSVersion("11.2")))
                     .preferredColorScheme(.light)
                     .environment(\.locale, .init(identifier: id))
             }
-            SimpleMode().environmentObject(PolicyManager(withVersion:  try! OSVersion("11.2") ))
+            SimpleMode().environmentObject(PolicyManager(withVersion:  try! OSVersion("11.2")))
                 .preferredColorScheme(.dark)
         }
     }

--- a/Nudge/UI/StandardMode/RightSide.swift
+++ b/Nudge/UI/StandardMode/RightSide.swift
@@ -194,6 +194,14 @@ struct StandardModeRightSide: View {
             HStack {
                 // Separate the buttons with a spacer
                 Spacer()
+                #if DEBUG
+                Button {
+                    Utils().userInitiatedExit()
+                } label: {
+                    Text(primaryQuitButtonText)
+                        .frame(minWidth: 35)
+                }
+                #endif
                 
                 if Utils().demoModeEnabled() || !pastRequiredInstallationDate && allowedDeferrals > self.deferralCountUI {
                     // secondaryQuitButton
@@ -261,11 +269,11 @@ struct StandardModeRightSidePreviews: PreviewProvider {
     static var previews: some View {
         Group {
             ForEach(["en", "es", "fr"], id: \.self) { id in
-                StandardModeRightSide().environmentObject(PolicyManager(withVersion:  try! OSVersion("11.2") ))
+                StandardModeRightSide().environmentObject(PolicyManager(withVersion:  try! OSVersion("11.2")))
                     .preferredColorScheme(.light)
                     .environment(\.locale, .init(identifier: id))
             }
-            StandardModeRightSide().environmentObject(PolicyManager(withVersion:  try! OSVersion("11.2") ))
+            StandardModeRightSide().environmentObject(PolicyManager(withVersion:  try! OSVersion("11.2")))
                 .preferredColorScheme(.dark)
         }
     }


### PR DESCRIPTION
This moves the `HostingWindowFinder` to the background per https://lostmoa.com/blog/ReadingTheCurrentWindowInANewSwiftUILifecycleApp/

This also adds some more debugging stuff to help better test nudge.