### PR TITLE
coerce string for requiredInstallationDate into Date

### DIFF
--- a/Nudge/Preferences/PreferencesStructure.swift
+++ b/Nudge/Preferences/PreferencesStructure.swift
@@ -190,10 +190,17 @@ extension OSVersionRequirement {
                 }
             }
         }
+        // Jamf JSON Schema for mobileconfigurations do not support Date types (JSON does not support it)
+        // In order to support this, an admin would need to pass a string and then coerce it into our Date format
+        // https://docs.jamf.com/technical-papers/jamf-pro/json-schema/10.26.0/Understanding_the_Structure_of_a_JSON_Schema_Manifest.html
+        if fromDictionary["requiredInstallationDate"] is String {
+            self.requiredInstallationDate = Utils().coerceStringToDate(dateString: fromDictionary["requiredInstallationDate"] as! String)
+        } else {
+            self.requiredInstallationDate = fromDictionary["requiredInstallationDate"] as? Date
+        }
         self.aboutUpdateURL = fromDictionary["aboutUpdateURL"] as? String
         self.aboutUpdateURLs = generatedAboutUpdateURLs
         self.majorUpgradeAppPath = fromDictionary["majorUpgradeAppPath"] as? String
-        self.requiredInstallationDate = fromDictionary["requiredInstallationDate"] as? Date
         self.requiredMinimumOSVersion = fromDictionary["requiredMinimumOSVersion"] as? String
         self.targetedOSVersions = fromDictionary["targetedOSVersions"] as? [String]
     }
@@ -438,18 +445,18 @@ extension UpdateElement {
     init(data: Data) throws {
         self = try newJSONDecoder().decode(UpdateElement.self, from: data)
     }
-    
+
     init(_ json: String, using encoding: String.Encoding = .utf8) throws {
         guard let data = json.data(using: encoding) else {
             throw NSError(domain: "JSONDecoding", code: 0, userInfo: nil)
         }
         try self.init(data: data)
     }
-    
+
     init(fromURL url: URL) throws {
         try self.init(data: try Data(contentsOf: url))
     }
-    
+
     func with(
         language: String?? = nil,
         actionButtonText: String?? = nil,
@@ -477,11 +484,11 @@ extension UpdateElement {
             subHeader: subHeader ?? self.subHeader
         )
     }
-    
+
     func jsonData() throws -> Data {
         return try newJSONEncoder().encode(self)
     }
-    
+
     func jsonString(encoding: String.Encoding = .utf8) throws -> String? {
         return String(data: try self.jsonData(), encoding: encoding)
     }

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -37,6 +37,12 @@ struct Utils {
         NSApp.windows[0].center()
     }
 
+    func coerceStringToDate(dateString: String) -> Date {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
+        return dateFormatter.date(from: dateString) ?? Date()
+    }
+
     func createImageData(fileImagePath: String) -> NSImage {
         utilsLog.debug("Creating image path for \(fileImagePath, privacy: .public)")
         let urlPath = NSURL(fileURLWithPath: fileImagePath)


### PR DESCRIPTION
So I want to put this up and have a discussion. This would allow you to pass a String for the `requiredInstallationDate` key.

What this basically solves is Jamf JSON Schema, allowing someone to finish that and maybe help jamf users. It appears that unless people sign their profiles before pushing them, jamf breaks them.

This is a workaround to workaround multiple bad behaviors that jamf has, so I don't want to necessarily merge it. I'm looking for feedback both from jamf users and non-jamf users.

Food for thought: the JSON takes a String for this key, because JSON doesn't support `data`. Swift can handle this natively for us though and converts it. NSUserDefaults though has to have this coerce logic, so it's not as elegant.