### PR TITLE
Fix bug in getOSVersionRequirements

### DIFF
--- a/Nudge/Preferences/DefaultPreferencesNudge.swift
+++ b/Nudge/Preferences/DefaultPreferencesNudge.swift
@@ -18,7 +18,7 @@ let attemptToFetchMajorUpgrade = optionalFeaturesProfile?["attemptToFetchMajorUp
 let enforceMinorUpdates = optionalFeaturesProfile?["enforceMinorUpdates"] as? Bool ?? optionalFeaturesJSON?.enforceMinorUpdates ?? true
 
 // osVersionRequirements
-let osVersionRequirementsProfile = getOSVersionRequirementsProfile(currentOSVersion: currentOSVersion)
+let osVersionRequirementsProfile = getOSVersionRequirementsProfile()
 let osVersionRequirementsJSON = getOSVersionRequirementsJSON()
 let majorUpgradeAppPath = osVersionRequirementsProfile?.majorUpgradeAppPath ?? osVersionRequirementsJSON?.majorUpgradeAppPath ?? ""
 let requiredInstallationDate = osVersionRequirementsProfile?.requiredInstallationDate ?? osVersionRequirementsJSON?.requiredInstallationDate ?? Date(timeIntervalSince1970: 0)

--- a/Nudge/Preferences/DefaultPreferencesNudge.swift
+++ b/Nudge/Preferences/DefaultPreferencesNudge.swift
@@ -7,6 +7,9 @@
 
 import Foundation
 
+// Globals
+let currentOSVersion = OSVersion(ProcessInfo().operatingSystemVersion).description
+
 // optionalFeatures
 let optionalFeaturesProfile = getOptionalFeaturesProfile()
 let optionalFeaturesJSON = getOptionalFeaturesJSON()
@@ -15,7 +18,7 @@ let attemptToFetchMajorUpgrade = optionalFeaturesProfile?["attemptToFetchMajorUp
 let enforceMinorUpdates = optionalFeaturesProfile?["enforceMinorUpdates"] as? Bool ?? optionalFeaturesJSON?.enforceMinorUpdates ?? true
 
 // osVersionRequirements
-let osVersionRequirementsProfile = getOSVersionRequirementsProfile()
+let osVersionRequirementsProfile = getOSVersionRequirementsProfile(currentOSVersion: currentOSVersion)
 let osVersionRequirementsJSON = getOSVersionRequirementsJSON()
 let majorUpgradeAppPath = osVersionRequirementsProfile?.majorUpgradeAppPath ?? osVersionRequirementsJSON?.majorUpgradeAppPath ?? ""
 let requiredInstallationDate = osVersionRequirementsProfile?.requiredInstallationDate ?? osVersionRequirementsJSON?.requiredInstallationDate ?? Date(timeIntervalSince1970: 0)

--- a/Nudge/Utilities/Preferences.swift
+++ b/Nudge/Utilities/Preferences.swift
@@ -52,7 +52,7 @@ func getOptionalFeaturesJSON() -> OptionalFeatures? {
 // osVersionRequirements
 // Mutate the profile into our required construct and then compare currentOS against targetedOSVersions
 // Even if profile/JSON is installed, return nil if in demo-mode
-func getOSVersionRequirementsProfile(currentOSVersion: String) -> OSVersionRequirement? {
+func getOSVersionRequirementsProfile() -> OSVersionRequirement? {
     if Utils().demoModeEnabled() {
         return nil
     }

--- a/Nudge/Utilities/Preferences.swift
+++ b/Nudge/Utilities/Preferences.swift
@@ -52,7 +52,7 @@ func getOptionalFeaturesJSON() -> OptionalFeatures? {
 // osVersionRequirements
 // Mutate the profile into our required construct and then compare currentOS against targetedOSVersions
 // Even if profile/JSON is installed, return nil if in demo-mode
-func getOSVersionRequirementsProfile() -> OSVersionRequirement? {
+func getOSVersionRequirementsProfile(currentOSVersion: String) -> OSVersionRequirement? {
     if Utils().demoModeEnabled() {
         return nil
     }
@@ -64,7 +64,7 @@ func getOSVersionRequirementsProfile() -> OSVersionRequirement? {
     }
     if !requirements.isEmpty {
         for (_ , subPreferences) in requirements.enumerated() {
-            if subPreferences.targetedOSVersions?.contains(OSVersion(ProcessInfo().operatingSystemVersion).description) == true {
+            if subPreferences.targetedOSVersions?.contains(currentOSVersion) == true || Utils().versionGreaterThanOrEqual(currentVersion: currentOSVersion, newVersion: subPreferences.requiredMinimumOSVersion ?? "0.0")  {
                 return subPreferences
             }
         }
@@ -81,7 +81,7 @@ func getOSVersionRequirementsJSON() -> OSVersionRequirement? {
     }
     if let requirements = nudgeJSONPreferences?.osVersionRequirements {
         for (_ , subPreferences) in requirements.enumerated() {
-            if subPreferences.targetedOSVersions?.contains(OSVersion(ProcessInfo().operatingSystemVersion).description) == true {
+            if subPreferences.targetedOSVersions?.contains(currentOSVersion) == true || Utils().versionGreaterThanOrEqual(currentVersion: currentOSVersion, newVersion: subPreferences.requiredMinimumOSVersion ?? "0.0") {
                 return subPreferences
             }
         }

--- a/Nudge/Utilities/UILogic.swift
+++ b/Nudge/Utilities/UILogic.swift
@@ -11,7 +11,7 @@ import Foundation
 // This likely needs to be refactored into PolicyManager.swift, but I wanted all functions out of Nudge.swift for now
 // Start doing a basic check
 func nudgeStartLogic() {
-    if Utils().fullyUpdated(currentOSVersion: currentOSVersion) {
+    if Utils().fullyUpdated() {
         // Because Nudge will bail if it detects installed OS >= required OS, this will cause the Xcode preview to fail.
         // https://zacwhite.com/2020/detecting-swiftui-previews/
         if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1" {
@@ -30,7 +30,7 @@ func nudgeStartLogic() {
                 Utils().exitNudge()
             }
         }
-    } else if enforceMinorUpdates == false && Utils().requireMajorUpgrade(currentOSVersion: currentOSVersion) == false {
+    } else if enforceMinorUpdates == false && Utils().requireMajorUpgrade() == false {
         let msg = "Device requires a minor update but enforceMinorUpdates is false"
         uiLog.info("\(msg, privacy: .public)")
         Utils().exitNudge()

--- a/Nudge/Utilities/UILogic.swift
+++ b/Nudge/Utilities/UILogic.swift
@@ -11,7 +11,7 @@ import Foundation
 // This likely needs to be refactored into PolicyManager.swift, but I wanted all functions out of Nudge.swift for now
 // Start doing a basic check
 func nudgeStartLogic() {
-    if Utils().fullyUpdated() {
+    if Utils().fullyUpdated(currentOSVersion: currentOSVersion) {
         // Because Nudge will bail if it detects installed OS >= required OS, this will cause the Xcode preview to fail.
         // https://zacwhite.com/2020/detecting-swiftui-previews/
         if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1" {
@@ -30,7 +30,7 @@ func nudgeStartLogic() {
                 Utils().exitNudge()
             }
         }
-    } else if enforceMinorUpdates == false && Utils().requireMajorUpgrade() == false {
+    } else if enforceMinorUpdates == false && Utils().requireMajorUpgrade(currentOSVersion: currentOSVersion) == false {
         let msg = "Device requires a minor update but enforceMinorUpdates is false"
         uiLog.info("\(msg, privacy: .public)")
         Utils().exitNudge()

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -69,7 +69,7 @@ struct Utils {
         return forceScreenShotIconMode
     }
 
-    func fullyUpdated(currentOSVersion: String) -> Bool {
+    func fullyUpdated() -> Bool {
         let fullyUpdated = versionGreaterThanOrEqual(currentVersion: currentOSVersion, newVersion: requiredMinimumOSVersion)
         if fullyUpdated {
             let msg = "Current operating system (\(currentOSVersion)) is greater than or equal to required operating system (\(requiredMinimumOSVersion))"
@@ -308,7 +308,7 @@ struct Utils {
         return requireDualQuitButtons
     }
 
-    func requireMajorUpgrade(currentOSVersion: String) -> Bool {
+    func requireMajorUpgrade() -> Bool {
         if requiredMinimumOSVersion == "0.0" {
             let msg = "Device requireMajorUpgrade: false"
             utilsLog.debug("\(msg, privacy: .public)")
@@ -331,7 +331,7 @@ struct Utils {
     func updateDevice() {
         let msg = "User clicked updateDevice"
         utilsLog.info("\(msg, privacy: .public)")
-        if requireMajorUpgrade(currentOSVersion: currentOSVersion) {
+        if requireMajorUpgrade() {
             NSWorkspace.shared.open(URL(fileURLWithPath: majorUpgradeAppPath))
         } else {
             NSWorkspace.shared.open(URL(fileURLWithPath: "/System/Library/PreferencePanes/SoftwareUpdate.prefPane"))

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -69,11 +69,10 @@ struct Utils {
         return forceScreenShotIconMode
     }
 
-    func fullyUpdated() -> Bool {
-        let currentVersion = OSVersion(ProcessInfo().operatingSystemVersion).description
-        let fullyUpdated = versionGreaterThanOrEqual(currentVersion: currentVersion, newVersion: requiredMinimumOSVersion)
+    func fullyUpdated(currentOSVersion: String) -> Bool {
+        let fullyUpdated = versionGreaterThanOrEqual(currentVersion: currentOSVersion, newVersion: requiredMinimumOSVersion)
         if fullyUpdated {
-            let msg = "Current operating system (\(currentVersion)) is greater than or equal to required operating system (\(requiredMinimumOSVersion))"
+            let msg = "Current operating system (\(currentOSVersion)) is greater than or equal to required operating system (\(requiredMinimumOSVersion))"
             utilsLog.info("\(msg, privacy: .public)")
             return true
         } else {
@@ -309,13 +308,13 @@ struct Utils {
         return requireDualQuitButtons
     }
 
-    func requireMajorUpgrade() -> Bool {
+    func requireMajorUpgrade(currentOSVersion: String) -> Bool {
         if requiredMinimumOSVersion == "0.0" {
             let msg = "Device requireMajorUpgrade: false"
             utilsLog.debug("\(msg, privacy: .public)")
             return false
         }
-        let requireMajorUpdate = versionGreaterThanOrEqual(currentVersion: OSVersion(ProcessInfo().operatingSystemVersion).description, newVersion: requiredMinimumOSVersion)
+        let requireMajorUpdate = versionGreaterThanOrEqual(currentVersion: currentOSVersion, newVersion: requiredMinimumOSVersion)
         utilsLog.info("Device requireMajorUpgrade: \(requireMajorUpdate, privacy: .public)")
         return requireMajorUpdate
     }
@@ -332,7 +331,7 @@ struct Utils {
     func updateDevice() {
         let msg = "User clicked updateDevice"
         utilsLog.info("\(msg, privacy: .public)")
-        if requireMajorUpgrade() {
+        if requireMajorUpgrade(currentOSVersion: currentOSVersion) {
             NSWorkspace.shared.open(URL(fileURLWithPath: majorUpgradeAppPath))
         } else {
             NSWorkspace.shared.open(URL(fileURLWithPath: "/System/Library/PreferencePanes/SoftwareUpdate.prefPane"))


### PR DESCRIPTION
When currentOSVersion > requiredMinimumOSVersion and targetedOSVersions does not include currentOSVersion, Nudge returns `0.0` as the version.

Addresses: https://github.com/macadmins/nudge/issues/146