### PR TITLE
Catches instances where the file path is not readable.

### DIFF
--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -46,7 +46,13 @@ struct Utils {
     func createImageData(fileImagePath: String) -> NSImage {
         utilsLog.debug("Creating image path for \(fileImagePath, privacy: .public)")
         let urlPath = NSURL(fileURLWithPath: fileImagePath)
-        let imageData:NSData = NSData(contentsOf: urlPath as URL)!
+        var imageData = NSData()
+        do {
+            imageData = try NSData(contentsOf: urlPath as URL)
+        } catch {
+            let errorImageConfig = NSImage.SymbolConfiguration(pointSize: 200, weight: .regular)
+            return NSImage(systemSymbolName: "questionmark.square.dashed", accessibilityDescription: nil)!.withSymbolConfiguration(errorImageConfig)!
+        }
         return NSImage(data: imageData as Data)!
     }
 


### PR DESCRIPTION
This can occur as "FileManager.default.fileExists(atPath:..." will return true if the file exists but not necessarily if it is readable (this caught me out a couple of times)

Will return SF Symbol questionmark.square.dashed as default "no image found"

testing:
reference a file that is present but you do not have read access to. 