### PR TITLE
Merge fixes from dev branch

### DIFF
--- a/Nudge/Preferences/DefaultPreferencesNudge.swift
+++ b/Nudge/Preferences/DefaultPreferencesNudge.swift
@@ -21,6 +21,7 @@ let enforceMinorUpdates = optionalFeaturesProfile?["enforceMinorUpdates"] as? Bo
 let osVersionRequirementsProfile = getOSVersionRequirementsProfile()
 let osVersionRequirementsJSON = getOSVersionRequirementsJSON()
 let majorUpgradeAppPath = osVersionRequirementsProfile?.majorUpgradeAppPath ?? osVersionRequirementsJSON?.majorUpgradeAppPath ?? ""
+let majorUpgradeAppPathExists = FileManager.default.fileExists(atPath: majorUpgradeAppPath)
 let requiredInstallationDate = osVersionRequirementsProfile?.requiredInstallationDate ?? osVersionRequirementsJSON?.requiredInstallationDate ?? Date(timeIntervalSince1970: 0)
 let requiredMinimumOSVersion = osVersionRequirementsProfile?.requiredMinimumOSVersion ?? osVersionRequirementsJSON?.requiredMinimumOSVersion ?? "0.0"
 let aboutUpdateURL = getAboutUpdateURL(OSVerReq: osVersionRequirementsProfile) ?? getAboutUpdateURL(OSVerReq: osVersionRequirementsJSON) ?? ""

--- a/Nudge/UI/Main.swift
+++ b/Nudge/UI/Main.swift
@@ -52,12 +52,13 @@ struct Main: App {
     var body: some Scene {
         #if DEBUG
         WindowGroup {
-            TabView {
+            VSplitView {
                 ContentView(simpleModePreview: false).environmentObject(manager)
                     .frame(width: 900, height: 450)
                 ContentView(simpleModePreview: true).environmentObject(manager)
                     .frame(width: 900, height: 450)
             }
+            .frame(height: 900)
         }
         // Hide Title Bar
         .windowStyle(HiddenTitleBarWindowStyle())

--- a/Nudge/UI/SimpleMode/SimpleMode.swift
+++ b/Nudge/UI/SimpleMode/SimpleMode.swift
@@ -121,15 +121,6 @@ struct SimpleMode: View {
 
                 // Separate the buttons with a spacer
                 Spacer()
-                
-                #if DEBUG
-                Button {
-                    Utils().userInitiatedExit()
-                } label: {
-                    Text(primaryQuitButtonText)
-                        .frame(minWidth: 35)
-                }
-                #endif
 
                 if Utils().demoModeEnabled() || !pastRequiredInstallationDate && allowedDeferrals > self.deferralCountUI {
                     // secondaryQuitButton

--- a/Nudge/UI/SimpleMode/SimpleMode.swift
+++ b/Nudge/UI/SimpleMode/SimpleMode.swift
@@ -89,11 +89,12 @@ struct SimpleMode: View {
                 }
 
                 // actionButton
-                Button(action: Utils().updateDevice, label: {
+                Button(action: {
+                    Utils().updateDevice()
+                }) {
                     Text(actionButtonText)
                         .frame(minWidth: 120)
-                    }
-                )
+                }
                 .keyboardShortcut(.defaultAction)
             }
             .frame(height: 390)

--- a/Nudge/UI/StandardMode/RightSide.swift
+++ b/Nudge/UI/StandardMode/RightSide.swift
@@ -60,12 +60,14 @@ struct StandardModeRightSide: View {
             
             // I'm kind of impressed with myself
             VStack {
+                Spacer()
+                    .frame(height: 10)
                 // mainContentHeader / mainContentSubHeader
-                HStack(alignment: .bottom) {
+                HStack(alignment: .center) {
                     VStack(alignment: .leading, spacing: 1) {
                         HStack {
                             Text(mainContentHeader)
-                                .font(.callout)
+                                 .font(.callout)
                                 .fontWeight(.bold)
                             Spacer()
                         }
@@ -84,7 +86,7 @@ struct StandardModeRightSide: View {
                     }
                     .keyboardShortcut(.defaultAction)
                 }
-                .frame(width: 510, height: 50)
+                .frame(width: 510)
                 
                 // Horizontal line
                 HStack{
@@ -189,7 +191,7 @@ struct StandardModeRightSide: View {
             }
             .background(Color.secondary.opacity(0.1))
             .cornerRadius(5)
-            .frame(width: 550)
+            .frame(width: 550, height: 350)
                 
             // Bottom buttons
             HStack {

--- a/Nudge/UI/StandardMode/RightSide.swift
+++ b/Nudge/UI/StandardMode/RightSide.swift
@@ -195,14 +195,6 @@ struct StandardModeRightSide: View {
             HStack {
                 // Separate the buttons with a spacer
                 Spacer()
-                #if DEBUG
-                Button {
-                    Utils().userInitiatedExit()
-                } label: {
-                    Text(primaryQuitButtonText)
-                        .frame(minWidth: 35)
-                }
-                #endif
                 
                 if Utils().demoModeEnabled() || !pastRequiredInstallationDate && allowedDeferrals > self.deferralCountUI {
                     // secondaryQuitButton

--- a/Nudge/UI/StandardMode/RightSide.swift
+++ b/Nudge/UI/StandardMode/RightSide.swift
@@ -77,10 +77,11 @@ struct StandardModeRightSide: View {
                     }
                     Spacer()
                     // actionButton
-                    Button(action: Utils().updateDevice, label: {
+                    Button(action: {
+                        Utils().updateDevice()
+                    }) {
                         Text(actionButtonText)
-                        }
-                    )
+                    }
                     .keyboardShortcut(.defaultAction)
                 }
                 .frame(width: 510, height: 50)

--- a/Nudge/UI/StandardMode/ScreenShotZoom.swift
+++ b/Nudge/UI/StandardMode/ScreenShotZoom.swift
@@ -81,11 +81,8 @@ struct ScreenShotZoom: View {
 struct ScreenShotZoomPreview: PreviewProvider {
     static var previews: some View {
         Group {
-            ForEach(["en", "es", "fr"], id: \.self) { id in
-                ScreenShotZoom().environmentObject(PolicyManager(withVersion:  try! OSVersion("11.2") ))
-                    .preferredColorScheme(.light)
-                    .environment(\.locale, .init(identifier: id))
-            }
+            ScreenShotZoom().environmentObject(PolicyManager(withVersion:  try! OSVersion("11.2") ))
+                .preferredColorScheme(.light)
             ScreenShotZoom().environmentObject(PolicyManager(withVersion:  try! OSVersion("11.2") ))
                 .preferredColorScheme(.dark)
         }

--- a/Nudge/Utilities/Preferences.swift
+++ b/Nudge/Utilities/Preferences.swift
@@ -63,6 +63,10 @@ func getOSVersionRequirementsProfile() -> OSVersionRequirement? {
         }
     }
     if !requirements.isEmpty {
+        if requirements.count >= 2 {
+            let v1ErrorMsg = "Multiple hashes may result in undefined behavior. Please deploy a single hash for OS enforcement at this time."
+            prefsProfileLog.error("\(v1ErrorMsg, privacy: .public)")
+        }
         for (_ , subPreferences) in requirements.enumerated() {
             if subPreferences.targetedOSVersions?.contains(currentOSVersion) == true || Utils().versionGreaterThanOrEqual(currentVersion: currentOSVersion, newVersion: subPreferences.requiredMinimumOSVersion ?? "0.0")  {
                 return subPreferences
@@ -80,6 +84,10 @@ func getOSVersionRequirementsJSON() -> OSVersionRequirement? {
         return nil
     }
     if let requirements = nudgeJSONPreferences?.osVersionRequirements {
+        if requirements.count >= 2 {
+            let v1ErrorMsg = "Multiple hashes may result in undefined behavior. Please deploy a single hash for OS enforcement at this time."
+            prefsJSONLog.error("\(v1ErrorMsg, privacy: .public)")
+        }
         for (_ , subPreferences) in requirements.enumerated() {
             if subPreferences.targetedOSVersions?.contains(currentOSVersion) == true || Utils().versionGreaterThanOrEqual(currentVersion: currentOSVersion, newVersion: subPreferences.requiredMinimumOSVersion ?? "0.0") {
                 return subPreferences

--- a/Nudge/Utilities/UILogic.swift
+++ b/Nudge/Utilities/UILogic.swift
@@ -121,7 +121,7 @@ func needToActivateNudge(deferralCountVar: Int, lastRefreshTimeVar: Date) -> Boo
                 })
             }
             Utils().activateNudge()
-            Utils().updateDevice()
+            Utils().updateDevice(userClicked: false)
         } else {
             Utils().activateNudge()
         }

--- a/Nudge/Utilities/UILogic.swift
+++ b/Nudge/Utilities/UILogic.swift
@@ -78,7 +78,7 @@ func needToActivateNudge(deferralCountVar: Int, lastRefreshTimeVar: Date) -> Boo
     let runningApplications = NSWorkspace.shared.runningApplications
 
     // Don't nudge if major upgrade is frontmostApplication
-    if FileManager.default.fileExists(atPath: majorUpgradeAppPath) {
+    if majorUpgradeAppPathExists {
         if NSURL.fileURL(withPath: majorUpgradeAppPath) == frontmostApplication?.bundleURL {
             let msg = "majorUpgradeApp is currently the frontmostApplication"
             uiLog.info("\(msg, privacy: .public)")
@@ -110,8 +110,10 @@ func needToActivateNudge(deferralCountVar: Int, lastRefreshTimeVar: Date) -> Boo
                 if acceptableApps.contains(appName) {
                     continue
                 }
-                if NSURL.fileURL(withPath: majorUpgradeAppPath) == appBundle {
-                    continue
+                if majorUpgradeAppPathExists {
+                    if NSURL.fileURL(withPath: majorUpgradeAppPath) == appBundle {
+                        continue
+                    }
                 }
                 // Taken from nudge-python as there was a race condition with NSWorkspace
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.001, execute: {

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -345,6 +345,7 @@ struct Utils {
         let msg = "User clicked updateDevice"
         uiLog.notice("\(msg, privacy: .public)")
         if requireMajorUpgrade() {
+        if requireMajorUpgrade() && majorUpgradeAppPathExists {
             NSWorkspace.shared.open(URL(fileURLWithPath: majorUpgradeAppPath))
         } else {
             NSWorkspace.shared.open(URL(fileURLWithPath: "/System/Library/PreferencePanes/SoftwareUpdate.prefPane"))

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -341,10 +341,14 @@ struct Utils {
         return simpleModeEnabled
     }
 
-    func updateDevice() {
-        let msg = "User clicked updateDevice"
-        uiLog.notice("\(msg, privacy: .public)")
-        if requireMajorUpgrade() {
+    func updateDevice(userClicked: Bool = true) {
+        if userClicked {
+            let msg = "User clicked updateDevice"
+            uiLog.notice("\(msg, privacy: .public)")
+        } else {
+            let msg = "Synthetically clicked updateDevice due to allowedDeferral count"
+            uiLog.notice("\(msg, privacy: .public)")
+        }
         if requireMajorUpgrade() && majorUpgradeAppPathExists {
             NSWorkspace.shared.open(URL(fileURLWithPath: majorUpgradeAppPath))
         } else {

--- a/build_assets/postinstall-launchagent
+++ b/build_assets/postinstall-launchagent
@@ -44,6 +44,8 @@ if [[ $3 == "/" ]] ; then
   else
     # Unload the agent so it can be triggered on re-install
     /bin/launchctl asuser "${console_user_uid}" /bin/launchctl unload -w "$3${launch_agent_base_path}${launch_agent_plist_name}"
+    # Kill Nudge just in case (say someone manually opens it and not launched via launchagent
+    /usr/bin/killall Nudge
     # Load the launch agent
     /bin/launchctl asuser "${console_user_uid}" /bin/launchctl load -w "$3${launch_agent_base_path}${launch_agent_plist_name}"
   fi


### PR DESCRIPTION
- Fix nudge crash when not passing `majorUpgradeAppPath` key
- Fix development UI rendering to not look terrible
- Remove extra `later` button from debug
- Fix centering of `Update Device` button after breaking it in a previous commit
- Fix ScreenShotPreview
- Warn when multiple `osVersionRequirements` hashes are passed due to bugs in the code that will need to be addressed in v1.1
- Force Nudge to exit on upgrades if users have manually opened
- Log user vs synthetic clicks of `Update Device`
- Fix issues when image file paths have bad permissions (https://github.com/macadmins/nudge/pull/155) thanks @bartreardon 