### PR TITLE
Force \\n to \n on mainContentText

### DIFF
--- a/Nudge/UI/StandardMode/RightSide.swift
+++ b/Nudge/UI/StandardMode/RightSide.swift
@@ -110,7 +110,7 @@ struct StandardModeRightSide: View {
                 
                 // mainContentText
                 HStack {
-                    Text(mainContentText)
+                    Text(mainContentText.replacingOccurrences(of: "\\n", with: "\n"))
                         .font(.callout)
                         .font(.body)
                         .fontWeight(.regular)


### PR DESCRIPTION
NSUserDefaults converts "\n" in strings to "\\n" because it's a database.

https://stackoverflow.com/questions/35053698/newline-n-not-working-in-swift

This forces it to work by resetting it to a new line.