### PR TITLE
Add major macOS upgrade support for upcoming Monterey release

### DIFF
--- a/Nudge/Preferences/DefaultPreferencesNudge.swift
+++ b/Nudge/Preferences/DefaultPreferencesNudge.swift
@@ -9,12 +9,13 @@ import Foundation
 
 // Globals
 let currentOSVersion = OSVersion(ProcessInfo().operatingSystemVersion).description
+var fetchMajorUpgradeSuccessful = false
 
 // optionalFeatures
 let optionalFeaturesProfile = getOptionalFeaturesProfile()
 let optionalFeaturesJSON = getOptionalFeaturesJSON()
 let asyncronousSoftwareUpdate = optionalFeaturesProfile?["asyncronousSoftwareUpdate"] as? Bool ?? optionalFeaturesJSON?.asyncronousSoftwareUpdate ?? true
-let attemptToFetchMajorUpgrade = optionalFeaturesProfile?["attemptToFetchMajorUpgrade"] as? Bool ?? optionalFeaturesJSON?.attemptToFetchMajorUpgrade ?? false
+let attemptToFetchMajorUpgrade = optionalFeaturesProfile?["attemptToFetchMajorUpgrade"] as? Bool ?? optionalFeaturesJSON?.attemptToFetchMajorUpgrade ?? true
 let enforceMinorUpdates = optionalFeaturesProfile?["enforceMinorUpdates"] as? Bool ?? optionalFeaturesJSON?.enforceMinorUpdates ?? true
 
 // osVersionRequirements

--- a/Nudge/UI/Main.swift
+++ b/Nudge/UI/Main.swift
@@ -65,7 +65,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             let msg = "Due to a bug in Big Sur 11.3 and lower, Nudge cannot reliably use /usr/sbin/softwareupdate to download updates. See https://openradar.appspot.com/radar?id=4987491098558464 for more information regarding this issue."
             softwareupdateDownloadLog.warning("\(msg, privacy: .public)")
         } else {
-            if asyncronousSoftwareUpdate {
+            if asyncronousSoftwareUpdate && Utils().requireMajorUpgrade() == false {
                 DispatchQueue(label: "nudge-su", attributes: .concurrent).asyncAfter(deadline: .now(), execute: {
                     SoftwareUpdate().Download()
                 })
@@ -83,6 +83,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             sleep(UInt32(randomDelaySeconds))
         }
         self.runSoftwareUpdate()
+        if Utils().requireMajorUpgrade() == true && fetchMajorUpgradeSuccessful == false && majorUpgradeAppPathExists == false {
+            let msg = "Unable to fetch major upgrade and application missing, exiting Nudge"
+            uiLog.notice("\(msg, privacy: .public)")
+            shouldExit = true
+            AppKit.NSApp.terminate(nil)
+        }
     }
 }
 

--- a/Nudge/UI/Main.swift
+++ b/Nudge/UI/Main.swift
@@ -83,7 +83,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             sleep(UInt32(randomDelaySeconds))
         }
         self.runSoftwareUpdate()
-        if Utils().requireMajorUpgrade() == true && fetchMajorUpgradeSuccessful == false && majorUpgradeAppPathExists == false {
+        if Utils().requireMajorUpgrade() && fetchMajorUpgradeSuccessful == false && majorUpgradeAppPathExists == false {
             let msg = "Unable to fetch major upgrade and application missing, exiting Nudge"
             uiLog.notice("\(msg, privacy: .public)")
             shouldExit = true

--- a/Nudge/Utilities/SoftwareUpdate.swift
+++ b/Nudge/Utilities/SoftwareUpdate.swift
@@ -47,27 +47,25 @@ class SoftwareUpdate {
     func Download() {
         softwareupdateDownloadLog.notice("enforceMinorUpdates: \(enforceMinorUpdates, privacy: .public)")
 
-        if Utils().getCPUTypeString() == "Apple Silicon" {
-            let msg = "Apple Silicon devices do not support automated softwareupdate calls. Please use MDM."
+        if Utils().getCPUTypeString() == "Apple Silicon" && Utils().requireMajorUpgrade() == false {
+            let msg = "Apple Silicon devices do not support automated softwareupdate downloads for minor updates. Please use MDM."
             softwareupdateListLog.debug("\(msg, privacy: .public)")
             return
         }
-
-        let softwareupdateList = self.List()
-
-        if softwareupdateList.contains("restart") {
-            let msg = "softwareupdate found available updates requiring a restart - attempting download"
+        
+        if Utils().requireMajorUpgrade() == true {
+            let msg = "device requires major upgrade - attempting download"
             softwareupdateListLog.notice("\(msg, privacy: .public)")
             let task = Process()
             task.launchPath = "/usr/sbin/softwareupdate"
-            task.arguments = ["--download", "--all"]
-
+            task.arguments = ["--fetch-full-installer", "--full-installer-version", requiredMinimumOSVersion]
+            
             let outputPipe = Pipe()
             let errorPipe = Pipe()
-
+            
             task.standardOutput = outputPipe
             task.standardError = errorPipe
-
+            
             do {
                 try task.run()
             } catch {
@@ -81,18 +79,58 @@ class SoftwareUpdate {
             let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
             
             let output = String(decoding: outputData, as: UTF8.self)
-            let error = String(decoding: errorData, as: UTF8.self)
+            let _ = String(decoding: errorData, as: UTF8.self)
             
             if task.terminationStatus != 0 {
-                softwareupdateDownloadLog.error("Error downloading software updates: \(error, privacy: .public)")
+                softwareupdateDownloadLog.error("Error downloading software updates: \(output, privacy: .public)")
             } else {
-                let msg = "softwareupdate successfully downloaded available updates"
+                fetchMajorUpgradeSuccessful = true
+                let msg = "softwareupdate successfully downloaded available update application"
                 softwareupdateListLog.notice("\(msg, privacy: .public)")
                 softwareupdateDownloadLog.info("\(output, privacy: .public)")
             }
         } else {
-            let msg = "softwareupdate did not find any available updates requiring a restart - skipping download"
-            softwareupdateListLog.notice("\(msg, privacy: .public)")
+            let softwareupdateList = self.List()
+            
+            if softwareupdateList.contains("restart") {
+                let msg = "softwareupdate found available updates requiring a restart - attempting download"
+                softwareupdateListLog.notice("\(msg, privacy: .public)")
+                let task = Process()
+                task.launchPath = "/usr/sbin/softwareupdate"
+                task.arguments = ["--download", "--all"]
+                
+                let outputPipe = Pipe()
+                let errorPipe = Pipe()
+                
+                task.standardOutput = outputPipe
+                task.standardError = errorPipe
+                
+                do {
+                    try task.run()
+                } catch {
+                    let msg = "Error downloading software updates"
+                    softwareupdateListLog.error("\(msg, privacy: .public)")
+                }
+                
+                task.waitUntilExit()
+                
+                let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+                let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+                
+                let output = String(decoding: outputData, as: UTF8.self)
+                let error = String(decoding: errorData, as: UTF8.self)
+                
+                if task.terminationStatus != 0 {
+                    softwareupdateDownloadLog.error("Error downloading software updates: \(error, privacy: .public)")
+                } else {
+                    let msg = "softwareupdate successfully downloaded available updates"
+                    softwareupdateListLog.notice("\(msg, privacy: .public)")
+                    softwareupdateDownloadLog.info("\(output, privacy: .public)")
+                }
+            } else {
+                let msg = "softwareupdate did not find any available updates requiring a restart - skipping download"
+                softwareupdateListLog.notice("\(msg, privacy: .public)")
+            }
         }
     }
 }

--- a/Nudge/Utilities/SoftwareUpdate.swift
+++ b/Nudge/Utilities/SoftwareUpdate.swift
@@ -53,7 +53,7 @@ class SoftwareUpdate {
             return
         }
         
-        if Utils().requireMajorUpgrade() == true {
+        if Utils().requireMajorUpgrade() {
             let msg = "device requires major upgrade - attempting download"
             softwareupdateListLog.notice("\(msg, privacy: .public)")
             let task = Process()

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -331,12 +331,7 @@ struct Utils {
     }
 
     func requireMajorUpgrade() -> Bool {
-        if requiredMinimumOSVersion == "0.0" {
-            let msg = "Device requireMajorUpgrade: false"
-            utilsLog.info("\(msg, privacy: .public)")
-            return false
-        }
-        let requireMajorUpdate = versionGreaterThanOrEqual(currentVersion: currentOSVersion, newVersion: requiredMinimumOSVersion)
+        let requireMajorUpdate = versionGreaterThan(currentVersion: String(getMajorRequiredNudgeOSVersion()), newVersion: String(getMajorOSVersion()))
         utilsLog.info("Device requireMajorUpgrade: \(requireMajorUpdate, privacy: .public)")
         return requireMajorUpdate
     }


### PR DESCRIPTION
Addresses: https://github.com/macadmins/nudge/issues/55

<img width="1234" alt="Screen Shot 2021-08-03 at 11 04 12 AM" src="https://user-images.githubusercontent.com/5685016/128049372-c9ca774f-30db-4fa3-a188-2d8e5aa692e7.png">

1. `attemptToFetchMajorUpgrade` is now defaulted to `True` so Nudge can easily support major OS upgrades
2. The current logic around minor updates is unchanged. Apple Silicon macs do not pre-fetch the installs and Intel macs pre-fetch the install if they are running macOS 11.3 or higher.
3. Apple Silicon and Intel macs seem to support `--fetch-full-installer --full-installer-version` without user input/root processes
4. If Nudge cannot fetch the installer and `majorUpgradeAppPath` key exists but the file does not exist on disk, Nudge bails.

I tested this with 
```json
{
  "osVersionRequirements": [
    {
      "majorUpgradeAppPath": "/Applications/Install macOS Monterey beta.app",
      "requiredInstallationDate": "2021-08-30T00:00:00Z",
      "requiredMinimumOSVersion": "12.0",
      "targetedOSVersions": [
        "11.0",
        "11.0.1",
        "11.1",
        "11.2",
        "11.2.1",
        "11.2.2",
        "11.2.3",
        "11.3",
        "11.3.1",
        "11.4",
        "11.5",
        "11.5.1"
      ]
    }
  ]
}
```

Nudge logs the following

```
Error downloading software updates: Scanning for 12.0 installer

Install failed with error: Update not found
```

but it can install the upgrade because I have manually installed the application to /Applications.