### PR TITLE
add acceptableApplicationBundleIDs feature

### DIFF
--- a/Example Assets/com.github.macadmins.Nudge.json
+++ b/Example Assets/com.github.macadmins.Nudge.json
@@ -1,5 +1,8 @@
 {
   "optionalFeatures": {
+    "acceptableApplicationBundleIDs": [
+      "us.zoom.xos"
+    ],
     "asyncronousSoftwareUpdate": true,
     "attemptToFetchMajorUpgrade": true,
     "enforceMinorUpdates": true

--- a/Example Assets/com.github.macadmins.Nudge.mobileconfig
+++ b/Example Assets/com.github.macadmins.Nudge.mobileconfig
@@ -21,6 +21,10 @@
         <integer>1</integer>
         <key>optionalFeatures</key>
         <dict>
+          <key>acceptableApplicationBundleIDs</key>
+          <array>
+            <string>us.zoom.xos</string>
+          </array>
           <key>asyncronousSoftwareUpdate</key>
           <true/>
           <key>attemptToFetchMajorUpgrade</key>

--- a/Nudge/Preferences/DefaultPreferencesNudge.swift
+++ b/Nudge/Preferences/DefaultPreferencesNudge.swift
@@ -14,6 +14,7 @@ var fetchMajorUpgradeSuccessful = false
 // optionalFeatures
 let optionalFeaturesProfile = getOptionalFeaturesProfile()
 let optionalFeaturesJSON = getOptionalFeaturesJSON()
+let customAcceptableApplicationBundleIDs = optionalFeaturesProfile?["acceptableApplicationBundleIDs"] as? [String] ?? optionalFeaturesJSON?.acceptableApplicationBundleIDs ?? [""]
 let asyncronousSoftwareUpdate = optionalFeaturesProfile?["asyncronousSoftwareUpdate"] as? Bool ?? optionalFeaturesJSON?.asyncronousSoftwareUpdate ?? true
 let attemptToFetchMajorUpgrade = optionalFeaturesProfile?["attemptToFetchMajorUpgrade"] as? Bool ?? optionalFeaturesJSON?.attemptToFetchMajorUpgrade ?? true
 let enforceMinorUpdates = optionalFeaturesProfile?["enforceMinorUpdates"] as? Bool ?? optionalFeaturesJSON?.enforceMinorUpdates ?? true
@@ -72,7 +73,7 @@ let oneDayDeferralButtonText = userInterfaceUpdateElementsProfile?["oneDayDeferr
 let oneHourDeferralButtonText = userInterfaceUpdateElementsProfile?["oneHourDeferralButtonText"] as? String ?? userInterfaceUpdateElementsJSON?.oneHourDeferralButtonText ?? "One Hour".localized(desiredLanguage: getDesiredLanguage())
 
 // Other important defaults
-let acceptableApps = [
+let builtInAcceptableApplicationBundleIDs = [
     "com.apple.loginwindow",
     "com.apple.systempreferences"
 ]

--- a/Nudge/Preferences/PreferencesStructure.swift
+++ b/Nudge/Preferences/PreferencesStructure.swift
@@ -58,6 +58,7 @@ extension NudgePreferences {
 
 // MARK: - OptionalFeatures
 struct OptionalFeatures: Codable {
+    var acceptableApplicationBundleIDs: [String]?
     var asyncronousSoftwareUpdate, attemptToFetchMajorUpgrade, enforceMinorUpdates: Bool?
 }
 
@@ -80,11 +81,13 @@ extension OptionalFeatures {
     }
 
     func with(
+        acceptableApplicationBundleIDs: [String]?? = nil,
         asyncronousSoftwareUpdate: Bool?? = nil,
         attemptToFetchMajorUpgrade: Bool?? = nil,
         enforceMinorUpdates: Bool?? = nil
     ) -> OptionalFeatures {
         return OptionalFeatures(
+            acceptableApplicationBundleIDs: acceptableApplicationBundleIDs ?? self.acceptableApplicationBundleIDs,
             asyncronousSoftwareUpdate: asyncronousSoftwareUpdate ?? self.asyncronousSoftwareUpdate,
             attemptToFetchMajorUpgrade: attemptToFetchMajorUpgrade ?? self.attemptToFetchMajorUpgrade,
             enforceMinorUpdates: enforceMinorUpdates ?? self.enforceMinorUpdates

--- a/Nudge/Utilities/UILogic.swift
+++ b/Nudge/Utilities/UILogic.swift
@@ -97,8 +97,8 @@ func needToActivateNudge(deferralCountVar: Int, lastRefreshTimeVar: Date) -> Boo
     }
 
     // Don't nudge if acceptable apps are frontmostApplication
-    if acceptableApps.contains((frontmostApplication?.bundleIdentifier!)!) {
-        let msg = "acceptableApp is currently the frontmostApplication"
+    if builtInAcceptableApplicationBundleIDs.contains((frontmostApplication?.bundleIdentifier!)!) || customAcceptableApplicationBundleIDs.contains((frontmostApplication?.bundleIdentifier!)!) {
+        let msg = "acceptableApplication (\(frontmostApplication?.bundleIdentifier ?? "")) is currently the frontmostApplication"
         uiLog.info("\(msg, privacy: .public)")
         return false
     }
@@ -122,7 +122,7 @@ func needToActivateNudge(deferralCountVar: Int, lastRefreshTimeVar: Date) -> Boo
             for runningApplication in runningApplications {
                 let appName = runningApplication.bundleIdentifier ?? ""
                 let appBundle = runningApplication.bundleURL
-                if acceptableApps.contains(appName) {
+                if builtInAcceptableApplicationBundleIDs.contains(appName) || customAcceptableApplicationBundleIDs.contains(appName) {
                     continue
                 }
                 if majorUpgradeAppPathExists {

--- a/Schema/jamf/com.github.macadmins.Nudge.json
+++ b/Schema/jamf/com.github.macadmins.Nudge.json
@@ -6,6 +6,19 @@
 			"title": "optionalFeatures",
 			"type": "object",
 			"properties": {
+				"acceptableApplicationBundleIDs": {
+					"description": "The bundle id of applications you allow without Nudge taking focus. You can specify a single bundle id or multiple.",
+					"type": "array",
+					"items": {
+						"options": {
+							"inputAttributes": {
+								"placeholder": "us.zoom.xos"
+							}
+						},
+						"type": "string",
+						"title": "acceptableApplications"
+					}
+				},
 				"asyncronousSoftwareUpdate": {
 					"default": true,
 					"description": "When disabled, Nudge will wait for Software Update to finish downloading (if any) updates before showing the UI.",


### PR DESCRIPTION
A new key `acceptableApplicationBundleIDs` is now available.

```
  "optionalFeatures": {
    "acceptableApplicationBundleIDs": [
      "us.zoom.xos"
    ]
  },
```