### PR TITLE
log/reset deferral counts across nudge events

### DIFF
--- a/Nudge/UI/ContentView.swift
+++ b/Nudge/UI/ContentView.swift
@@ -12,12 +12,13 @@ import SwiftUI
 
 class ViewState: ObservableObject {
     @Published var shouldExit = false
+    @Published var userDeferralCount = 0
 }
 
 // BackgroundView
 struct BackgroundView: View {
     @State var simpleModePreview: Bool
-    @StateObject var viewState = ViewState()
+    @StateObject var viewState = nudgePrimaryState
     var body: some View {
         if simpleMode() || simpleModePreview {
             SimpleMode(viewObserved: viewState)

--- a/Nudge/UI/DeferView.swift
+++ b/Nudge/UI/DeferView.swift
@@ -52,6 +52,7 @@ struct DeferView: View {
             Divider()
             HStack {
                 Button {
+                    Utils().logUserQuitDeferrals()
                     nudgeDefaults.set(nudgeCustomEventDate, forKey: "deferRunUntil")
                     userHasClickedDeferralQuitButton(deferralTime: nudgeCustomEventDate)
                     viewObserved.shouldExit.toggle()
@@ -81,11 +82,11 @@ struct DeviceViewPreview: PreviewProvider {
     static var previews: some View {
         Group {
             ForEach(["en", "es"], id: \.self) { id in
-                DeferView(viewObserved: ViewState())
+                DeferView(viewObserved: nudgePrimaryState)
                     .preferredColorScheme(.light)
                     .environment(\.locale, .init(identifier: id))
             }
-            DeferView(viewObserved: ViewState())
+            DeferView(viewObserved: nudgePrimaryState)
                 .preferredColorScheme(.dark)
         }
     }

--- a/Nudge/UI/SimpleMode/SimpleMode.swift
+++ b/Nudge/UI/SimpleMode/SimpleMode.swift
@@ -18,7 +18,6 @@ struct SimpleMode: View {
     // State variables
     @State var allowButtons = true
     @State var daysRemaining = Utils().getNumberOfDaysBetween()
-    @State var deferralCountUI = 0
     @State var hasClickedCustomDeferralButton = false
     @State var hasClickedSecondaryQuitButton = false
     @State var requireDualQuitButtons = false
@@ -113,7 +112,7 @@ struct SimpleMode: View {
                     HStack{
                         Text("Deferred Count:".localized(desiredLanguage: getDesiredLanguage()))
                             .font(.title2)
-                        Text(String(self.deferralCountUI))
+                        Text(String(viewObserved.userDeferralCount))
                             .foregroundColor(.secondary)
                             .font(.title2)
                             .fontWeight(.bold)
@@ -184,6 +183,7 @@ struct SimpleMode: View {
                             if allowUserQuitDeferrals {
                                 Menu("Defer") {
                                     Button {
+                                        Utils().logUserQuitDeferrals()
                                         nudgeDefaults.set(Calendar.current.date(byAdding: .minute, value: (0), to: nudgeEventDate), forKey: "deferRunUntil")
                                         Utils().userInitiatedExit()
                                     } label: {
@@ -192,6 +192,7 @@ struct SimpleMode: View {
                                     }
                                     if Utils().allow1HourDeferral() {
                                         Button {
+                                            Utils().logUserQuitDeferrals()
                                             nudgeDefaults.set(nudgeEventDate.addingTimeInterval(3600), forKey: "deferRunUntil")
                                             userHasClickedDeferralQuitButton(deferralTime: nudgeEventDate.addingTimeInterval(3600))
                                             Utils().userInitiatedExit()
@@ -202,6 +203,7 @@ struct SimpleMode: View {
                                     }
                                     if Utils().allow24HourDeferral() {
                                         Button {
+                                            Utils().logUserQuitDeferrals()
                                             nudgeDefaults.set(nudgeEventDate.addingTimeInterval(86400), forKey: "deferRunUntil")
                                             userHasClickedDeferralQuitButton(deferralTime: nudgeEventDate.addingTimeInterval(86400))
                                             Utils().userInitiatedExit()
@@ -223,6 +225,7 @@ struct SimpleMode: View {
                                 .frame(maxWidth: 100)
                             } else {
                                 Button {
+                                    Utils().logUserQuitDeferrals()
                                     Utils().userInitiatedExit()
                                 } label: {
                                     Text(primaryQuitButtonText)
@@ -249,8 +252,8 @@ struct SimpleMode: View {
             updateUI()
         }
         .onReceive(nudgeRefreshCycleTimer) { _ in
-            if needToActivateNudge(deferralCountVar: deferralCount, lastRefreshTimeVar: lastRefreshTime) {
-                self.deferralCountUI += 1
+            if needToActivateNudge(lastRefreshTimeVar: lastRefreshTime) {
+                viewObserved.userDeferralCount += 1
             }
             updateUI()
         }
@@ -283,11 +286,11 @@ struct SimpleModePreviews: PreviewProvider {
     static var previews: some View {
         Group {
             ForEach(["en", "es"], id: \.self) { id in
-                SimpleMode(viewObserved: ViewState())
+                SimpleMode(viewObserved: nudgePrimaryState)
                     .preferredColorScheme(.light)
                     .environment(\.locale, .init(identifier: id))
             }
-            SimpleMode(viewObserved: ViewState())
+            SimpleMode(viewObserved: nudgePrimaryState)
                 .preferredColorScheme(.dark)
         }
     }

--- a/Nudge/UI/StandardMode/LeftSide.swift
+++ b/Nudge/UI/StandardMode/LeftSide.swift
@@ -10,12 +10,12 @@ import SwiftUI
 
 // StandardModeLeftSide
 struct StandardModeLeftSide: View {
+    @ObservedObject var viewObserved: ViewState
     // Get the color scheme so we can dynamically change properties
     @Environment(\.colorScheme) var colorScheme
     
     // State variables
     @State var daysRemaining = Utils().getNumberOfDaysBetween()
-    @State var deferralCountUI = 0
     
     // Modal view for screenshot and device info
     @State var showDeviceInfo = false
@@ -120,7 +120,7 @@ struct StandardModeLeftSide: View {
                     HStack{
                         Text("Deferred Count:".localized(desiredLanguage: getDesiredLanguage()))
                         Spacer()
-                        Text(String(self.deferralCountUI))
+                        Text(String(viewObserved.userDeferralCount))
                             .foregroundColor(.secondary)
                     }
                 }
@@ -160,8 +160,8 @@ struct StandardModeLeftSide: View {
             updateUI()
         }
         .onReceive(nudgeRefreshCycleTimer) { _ in
-            if needToActivateNudge(deferralCountVar: deferralCount, lastRefreshTimeVar: lastRefreshTime) {
-                self.deferralCountUI += 1
+            if needToActivateNudge(lastRefreshTimeVar: lastRefreshTime) {
+                viewObserved.userDeferralCount += 1
             }
             updateUI()
         }
@@ -177,11 +177,11 @@ struct StandardModeLeftSidePreviews: PreviewProvider {
     static var previews: some View {
         Group {
             ForEach(["en", "es"], id: \.self) { id in
-                StandardModeLeftSide()
+                StandardModeLeftSide(viewObserved: nudgePrimaryState)
                     .preferredColorScheme(.light)
                     .environment(\.locale, .init(identifier: id))
             }
-            StandardModeLeftSide()
+            StandardModeLeftSide(viewObserved: nudgePrimaryState)
                 .preferredColorScheme(.dark)
         }
     }

--- a/Nudge/UI/StandardMode/RightSide.swift
+++ b/Nudge/UI/StandardMode/RightSide.swift
@@ -223,6 +223,7 @@ struct StandardModeRightSide: View {
                             if allowUserQuitDeferrals {
                                 Menu("Defer") {
                                     Button {
+                                        Utils().logUserQuitDeferrals()
                                         nudgeDefaults.set(Calendar.current.date(byAdding: .minute, value: (0), to: nudgeEventDate), forKey: "deferRunUntil")
                                         Utils().userInitiatedExit()
                                     } label: {
@@ -231,6 +232,7 @@ struct StandardModeRightSide: View {
                                     }
                                     if Utils().allow1HourDeferral() {
                                         Button {
+                                            Utils().logUserQuitDeferrals()
                                             nudgeDefaults.set(nudgeEventDate.addingTimeInterval(3600), forKey: "deferRunUntil")
                                             userHasClickedDeferralQuitButton(deferralTime: nudgeEventDate.addingTimeInterval(3600))
                                             Utils().userInitiatedExit()
@@ -241,6 +243,7 @@ struct StandardModeRightSide: View {
                                     }
                                     if Utils().allow24HourDeferral() {
                                         Button {
+                                            Utils().logUserQuitDeferrals()
                                             nudgeDefaults.set(nudgeEventDate.addingTimeInterval(86400), forKey: "deferRunUntil")
                                             userHasClickedDeferralQuitButton(deferralTime: nudgeEventDate.addingTimeInterval(86400))
                                             Utils().userInitiatedExit()
@@ -262,6 +265,7 @@ struct StandardModeRightSide: View {
                                 .frame(maxWidth: 100)
                             } else {
                                 Button {
+                                    Utils().logUserQuitDeferrals()
                                     Utils().userInitiatedExit()
                                 } label: {
                                     Text(primaryQuitButtonText)
@@ -306,11 +310,11 @@ struct StandardModeRightSidePreviews: PreviewProvider {
     static var previews: some View {
         Group {
             ForEach(["en", "es"], id: \.self) { id in
-                StandardModeRightSide(viewObserved: ViewState())
+                StandardModeRightSide(viewObserved: nudgePrimaryState)
                     .preferredColorScheme(.light)
                     .environment(\.locale, .init(identifier: id))
             }
-            StandardModeRightSide(viewObserved: ViewState())
+            StandardModeRightSide(viewObserved: nudgePrimaryState)
                 .preferredColorScheme(.dark)
         }
     }

--- a/Nudge/UI/StandardMode/StandardMode.swift
+++ b/Nudge/UI/StandardMode/StandardMode.swift
@@ -15,7 +15,7 @@ struct StandardMode: View {
     var body: some View {
         HStack {
             // Left side of Nudge
-            StandardModeLeftSide()
+            StandardModeLeftSide(viewObserved: viewObserved)
 
             // Vertical Line
             VStack{
@@ -38,11 +38,11 @@ struct StandardModePreviews: PreviewProvider {
     static var previews: some View {
         Group {
             ForEach(["en", "es"], id: \.self) { id in
-                StandardMode(viewObserved: ViewState())
+                StandardMode(viewObserved: nudgePrimaryState)
                     .preferredColorScheme(.light)
                     .environment(\.locale, .init(identifier: id))
             }
-            StandardMode(viewObserved: ViewState())
+            StandardMode(viewObserved: nudgePrimaryState)
                 .preferredColorScheme(.dark)
         }
     }

--- a/Nudge/Utilities/Preferences.swift
+++ b/Nudge/Utilities/Preferences.swift
@@ -12,6 +12,9 @@ let nudgeDefaults = UserDefaults.standard
 let language = NSLocale.current.languageCode!
 var nudgePrimaryState = ViewState()
 let deferRunUntil = UserDefaults.standard.object(forKey: "deferRunUntil") as? Date
+let userRequiredMinimumOSVersion = UserDefaults.standard.object(forKey: "requiredMinimumOSVersion") as? String ?? "0.0"
+var userSessionDeferrals = UserDefaults.standard.object(forKey: "userSessionDeferrals") as? Int ?? 0
+var userQuitDeferrals = UserDefaults.standard.object(forKey: "userQuitDeferrals") as? Int ?? 0
 
 // Get the language
 func getDesiredLanguage() -> String {

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -323,6 +323,31 @@ struct Utils {
         }
     }
 
+    func logUserQuitDeferrals(resetCount: Bool = false) {
+        if resetCount {
+            nudgeDefaults.set(0, forKey: "userQuitDeferrals")
+        } else {
+            nudgeDefaults.set(userQuitDeferrals+1, forKey: "userQuitDeferrals")
+        }
+    }
+
+    func logUserSessionDeferrals(resetCount: Bool = false) {
+        if resetCount {
+            nudgeDefaults.set(0, forKey: "userSessionDeferrals")
+        } else {
+            nudgeDefaults.set(nudgePrimaryState.userDeferralCount+1, forKey: "userSessionDeferrals")
+        }
+        
+    }
+
+    func logRequiredMinimumOSVersion() {
+        nudgeDefaults.set(requiredMinimumOSVersion, forKey: "requiredMinimumOSVersion")
+    }
+
+    func newNudgeEvent() -> Bool {
+        versionGreaterThan(currentVersion: requiredMinimumOSVersion, newVersion: userRequiredMinimumOSVersion)
+    }
+
     func openMoreInfo() {
         guard let url = URL(string: aboutUpdateURL) else {
             return


### PR DESCRIPTION
This required using more enhancements to `ObservableObject` which is part of https://github.com/macadmins/nudge/issues/189

- Addresses: https://github.com/macadmins/nudge/issues/197, https://github.com/macadmins/nudge/issues/21, https://github.com/macadmins/nudge/issues/205 

new NSUserDefault keys

```
userQuitDeferrals
userSessionDeferrals
requiredMinimumOSVersion
```

new log event for when these keys are rest
```
New Nudge event detected - resetting deferrals
```