### PR TITLE
Enhance nudge launch logic

### DIFF
--- a/Nudge/Preferences/DefaultPreferencesNudge.swift
+++ b/Nudge/Preferences/DefaultPreferencesNudge.swift
@@ -73,7 +73,15 @@ let oneDayDeferralButtonText = userInterfaceUpdateElementsProfile?["oneDayDeferr
 let oneHourDeferralButtonText = userInterfaceUpdateElementsProfile?["oneHourDeferralButtonText"] as? String ?? userInterfaceUpdateElementsJSON?.oneHourDeferralButtonText ?? "One Hour".localized(desiredLanguage: getDesiredLanguage())
 
 // Other important defaults
-let builtInAcceptableApplicationBundleIDs = [
-    "com.apple.loginwindow",
-    "com.apple.systempreferences"
-]
+#if DEBUG
+    let builtInAcceptableApplicationBundleIDs = [
+        "com.apple.loginwindow",
+        "com.apple.systempreferences",
+        "com.apple.dt.Xcode"
+    ]
+#else
+    let builtInAcceptableApplicationBundleIDs = [
+        "com.apple.loginwindow",
+        "com.apple.systempreferences"
+    ]
+#endif

--- a/Nudge/UI/ContentView.swift
+++ b/Nudge/UI/ContentView.swift
@@ -40,11 +40,7 @@ struct ContentView: View {
                 window?.standardWindowButton(.zoomButton)?.isHidden = true //this removes the green zoom button
                 window?.center() // center
                 window?.isMovable = false // not movable
-                #if DEBUG
-                    NSApp.activate(ignoringOtherApps: false) // bring to forefront upon launch
-                #else
-                    NSApp.activate(ignoringOtherApps: true) // bring to forefront upon launch
-                #endif
+                _ = needToActivateNudge(lastRefreshTimeVar: lastRefreshTime)
             }
         )
     }


### PR DESCRIPTION
Right now when Nudge first launches, if an application is in the acceptable apps list or custom acceptable apps list, Nudge will not honor those applications.

This is an enhancement based off slack discussions for https://github.com/macadmins/nudge/issues/180

With this change, Nudge will now honor all acceptable applications whether it's first launch of re-activation.