### PR TITLE
initial (working) attempt at versionRules

### DIFF
--- a/Example Assets/com.github.macadmins.Nudge.json
+++ b/Example Assets/com.github.macadmins.Nudge.json
@@ -31,19 +31,25 @@
       "majorUpgradeAppPath": "/Applications/Install macOS Big Sur.app",
       "requiredInstallationDate": "2021-08-28T00:00:00Z",
       "requiredMinimumOSVersion": "11.5.2",
-      "targetedOSVersions": [
-        "11.0",
-        "11.0.1",
-        "11.1",
-        "11.2",
-        "11.2.1",
-        "11.2.2",
-        "11.2.3",
-        "11.3",
-        "11.3.1",
-        "11.4",
-        "11.5",
-        "11.5.1"
+      "versionRules": [
+        {
+          "majorUpgradeAppPath": "/Applications/Install macOS Big Sur.app",
+          "requiredMinimumOSVersion": "11.5.2",
+          "requiredInstallationDate": "2021-08-28T00:00:00Z",
+          "rule": "11"
+        },
+        {
+          "majorUpgradeAppPath": "/Applications/Install macOS Big Sur.app",
+          "requiredMinimumOSVersion": "11.5.2",
+          "requiredInstallationDate": "2021-08-28T12:00:00Z",
+          "rule": "11.5.1"
+        },
+        {
+          "majorUpgradeAppPath": "/Applications/Install macOS Monterey.app",
+          "requiredMinimumOSVersion": "12.0.1",
+          "requiredInstallationDate": "2021-10-28T00:00:00Z",
+          "rule": "12"
+        }
       ]
     }
   ],

--- a/Example Assets/com.github.macadmins.Nudge.mobileconfig
+++ b/Example Assets/com.github.macadmins.Nudge.mobileconfig
@@ -70,20 +70,38 @@
             <date>2021-08-28T00:00:00Z</date>
             <key>requiredMinimumOSVersion</key>
             <string>11.5.2</string>
-            <key>targetedOSVersions</key>
+            <key>versionRules</key>
             <array>
-              <string>11.0</string>
-              <string>11.0.1</string>
-              <string>11.1</string>
-              <string>11.2</string>
-              <string>11.2.1</string>
-              <string>11.2.2</string>
-              <string>11.2.3</string>
-              <string>11.3</string>
-              <string>11.3.1</string>
-              <string>11.4</string>
-              <string>11.5</string>
-              <string>11.5.1</string>
+              <dict>
+                <key>majorUpgradeAppPath</key>
+                <string>/Applications/Install macOS Big Sur.app</string>
+                <key>requiredMinimumOSVersion</key>
+                <string>11.5.2</string>
+                <key>requiredInstallationDate</key>
+                <date>2021-08-28T00:00:00Z</date>
+                <key>rule</key>
+                <string>11</string>
+              </dict>
+              <dict>
+                <key>majorUpgradeAppPath</key>
+                <string>/Applications/Install macOS Big Sur.app</string>
+                <key>requiredMinimumOSVersion</key>
+                <string>11.5.2</string>
+                <key>requiredInstallationDate</key>
+                <date>2021-08-28T12:00:00Z</date>
+                <key>rule</key>
+                <string>11.5.1</string>
+              </dict>
+              <dict>
+                <key>majorUpgradeAppPath</key>
+                <string>/Applications/Install macOS Monterey.app</string>
+                <key>requiredMinimumOSVersion</key>
+                <string>12.0.1</string>
+                <key>requiredInstallationDate</key>
+                <date>2021-10-28T00:00:00Z</date>
+                <key>rule</key>
+                <string>12</string>
+              </dict>
             </array>
           </dict>
         </array>

--- a/Nudge/Preferences/DefaultPreferencesNudge.swift
+++ b/Nudge/Preferences/DefaultPreferencesNudge.swift
@@ -23,10 +23,11 @@ let enforceMinorUpdates = optionalFeaturesProfile?["enforceMinorUpdates"] as? Bo
 let osVersionRequirementsProfile = getOSVersionRequirementsProfile()
 let osVersionRequirementsJSON = getOSVersionRequirementsJSON()
 let majorUpgradeAppPath = osVersionRequirementsProfile?.majorUpgradeAppPath ?? osVersionRequirementsJSON?.majorUpgradeAppPath ?? ""
-let majorUpgradeAppPathExists = FileManager.default.fileExists(atPath: majorUpgradeAppPath)
+let majorUpgradeAppPathExists = FileManager.default.fileExists(atPath: getMajorUpgradeAppPath())
 let requiredInstallationDate = osVersionRequirementsProfile?.requiredInstallationDate ?? osVersionRequirementsJSON?.requiredInstallationDate ?? Date(timeIntervalSince1970: 0)
 let requiredMinimumOSVersion = osVersionRequirementsProfile?.requiredMinimumOSVersion ?? osVersionRequirementsJSON?.requiredMinimumOSVersion ?? "0.0"
 let aboutUpdateURL = getAboutUpdateURL(OSVerReq: osVersionRequirementsProfile) ?? getAboutUpdateURL(OSVerReq: osVersionRequirementsJSON) ?? ""
+let versionRules = osVersionRequirementsProfile?.versionRules ?? osVersionRequirementsJSON?.versionRules ?? nil
 
 // userExperience
 let userExperienceProfile = getUserExperienceProfile()

--- a/Nudge/Preferences/PreferencesStructure.swift
+++ b/Nudge/Preferences/PreferencesStructure.swift
@@ -110,7 +110,6 @@ struct OSVersionRequirement: Codable {
     var majorUpgradeAppPath: String?
     var requiredInstallationDate: Date?
     var requiredMinimumOSVersion: String?
-    var targetedOSVersions: [String]?
     var versionRules: [VersionRule]?
 }
 
@@ -139,7 +138,6 @@ extension OSVersionRequirement {
         self.aboutUpdateURLs = generatedAboutUpdateURLs
         self.majorUpgradeAppPath = fromDictionary["majorUpgradeAppPath"] as? String
         self.requiredMinimumOSVersion = fromDictionary["requiredMinimumOSVersion"] as? String
-        self.targetedOSVersions = fromDictionary["targetedOSVersions"] as? [String]
     }
 
     init(data: Data) throws {
@@ -163,7 +161,6 @@ extension OSVersionRequirement {
         majorUpgradeAppPath: String?? = nil,
         requiredInstallationDate: Date?? = nil,
         requiredMinimumOSVersion: String?? = nil,
-        targetedOSVersions: [String]?? = nil,
         versionRules: [VersionRule]?? = nil
     ) -> OSVersionRequirement {
         return OSVersionRequirement(
@@ -172,7 +169,6 @@ extension OSVersionRequirement {
             majorUpgradeAppPath: majorUpgradeAppPath ?? self.majorUpgradeAppPath,
             requiredInstallationDate: requiredInstallationDate ?? self.requiredInstallationDate,
             requiredMinimumOSVersion: requiredMinimumOSVersion ?? self.requiredMinimumOSVersion,
-            targetedOSVersions: targetedOSVersions ?? self.targetedOSVersions,
             versionRules: versionRules ?? self.versionRules
         )
     }

--- a/Nudge/UI/ContentView.swift
+++ b/Nudge/UI/ContentView.swift
@@ -18,8 +18,11 @@ class ViewState: ObservableObject {
     @Published var deferRunUntil = nudgeDefaults.object(forKey: "deferRunUntil") as? Date
     @Published var hasLoggedDeferralCountPastThreshhold = false
     @Published var hasLoggedDeferralCountPastThresholdDualQuitButtons = false
+    @Published var hasLoggedMajorOSVersion = false
+    @Published var hasLoggedMajorRequiredOSVersion = false
     @Published var hasLoggedPastRequiredInstallationDate = false
     @Published var hasLoggedRequireDualQuitButtons = false
+    @Published var hasLoggedRequireMajorUgprade = false
     @Published var lastRefreshTime = Utils().getInitialDate()
     @Published var requireDualQuitButtons = false
     @Published var shouldExit = false

--- a/Nudge/UI/StandardMode/LeftSide.swift
+++ b/Nudge/UI/StandardMode/LeftSide.swift
@@ -80,7 +80,7 @@ struct StandardModeLeftSide: View {
                     Text("Required OS Version:".localized(desiredLanguage: getDesiredLanguage()))
                         .fontWeight(.bold)
                     Spacer()
-                    Text(String(requiredMinimumOSVersion))
+                    Text(String(getRequiredMinimumOSVersion()))
                         .foregroundColor(.secondary)
                         .fontWeight(.bold)
                 }

--- a/Nudge/Utilities/Preferences.swift
+++ b/Nudge/Utilities/Preferences.swift
@@ -50,7 +50,7 @@ func getOptionalFeaturesJSON() -> OptionalFeatures? {
 }
 
 // osVersionRequirements
-// Mutate the profile into our required construct and then compare currentOS against targetedOSVersions
+// Mutate the profile into our required construct
 // Even if profile/JSON is installed, return nil if in demo-mode
 func getOSVersionRequirementsProfile() -> OSVersionRequirement? {
     if Utils().demoModeEnabled() {
@@ -77,7 +77,8 @@ func getOSVersionRequirementsProfile() -> OSVersionRequirement? {
     }
     return nil
 }
-// Loop through JSON osVersionRequirements preferences and then compare currentOS against targetedOSVersions
+// Loop through JSON osVersionRequirements preferences
+// Even if profile/JSON is installed, return nil if in demo-mode
 func getOSVersionRequirementsJSON() -> OSVersionRequirement? {
     if Utils().demoModeEnabled() {
         return nil

--- a/Nudge/Utilities/UILogic.swift
+++ b/Nudge/Utilities/UILogic.swift
@@ -10,6 +10,7 @@ import Foundation
 
 // Start doing a basic check
 func nudgeStartLogic() {
+    print(getRequiredInstallationDate())
     if Utils().newNudgeEvent() {
         let msg = "New Nudge event detected - resetting all deferral values"
         uiLog.notice("\(msg, privacy: .public)")
@@ -120,7 +121,7 @@ func needToActivateNudge() -> Bool {
 
     // Don't nudge if major upgrade is frontmostApplication
     if majorUpgradeAppPathExists {
-        if NSURL.fileURL(withPath: majorUpgradeAppPath) == frontmostApplication?.bundleURL {
+        if NSURL.fileURL(withPath: getMajorUpgradeAppPath()) == frontmostApplication?.bundleURL {
             let msg = "majorUpgradeApp is currently the frontmostApplication"
             uiLog.info("\(msg, privacy: .public)")
             return false
@@ -146,7 +147,7 @@ func needToActivateNudge() -> Bool {
                     continue
                 }
                 if majorUpgradeAppPathExists {
-                    if NSURL.fileURL(withPath: majorUpgradeAppPath) == appBundle {
+                    if NSURL.fileURL(withPath: getMajorUpgradeAppPath()) == appBundle {
                         continue
                     }
                 }

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -119,9 +119,9 @@ struct Utils {
     }
 
     func fullyUpdated() -> Bool {
-        let fullyUpdated = versionGreaterThanOrEqual(currentVersion: currentOSVersion, newVersion: requiredMinimumOSVersion)
+        let fullyUpdated = versionGreaterThanOrEqual(currentVersion: currentOSVersion, newVersion: getRequiredMinimumOSVersion())
         if fullyUpdated {
-            let msg = "Current operating system (\(currentOSVersion)) is greater than or equal to required operating system (\(requiredMinimumOSVersion))"
+            let msg = "Current operating system (\(currentOSVersion)) is greater than or equal to required operating system (\(getRequiredMinimumOSVersion()))"
             utilsLog.notice("\(msg, privacy: .public)")
             return true
         } else {
@@ -192,14 +192,20 @@ struct Utils {
 
     func getMajorOSVersion() -> Int {
         let MajorOSVersion = ProcessInfo().operatingSystemVersion.majorVersion
-        utilsLog.info("OS Version: \(MajorOSVersion, privacy: .public)")
+        if !nudgePrimaryState.hasLoggedMajorOSVersion {
+            nudgePrimaryState.hasLoggedMajorOSVersion = true
+            utilsLog.info("OS Version: \(MajorOSVersion, privacy: .public)")
+        }
         return MajorOSVersion
     }
 
     func getMajorRequiredNudgeOSVersion() -> Int {
-        let parts = requiredMinimumOSVersion.split(separator: ".", omittingEmptySubsequences: false)
+        let parts = getRequiredMinimumOSVersion().split(separator: ".", omittingEmptySubsequences: false)
         let majorRequiredNudgeOSVersion = Int((parts[0]))!
-        utilsLog.info("Major required OS version: \(majorRequiredNudgeOSVersion, privacy: .public)")
+        if !nudgePrimaryState.hasLoggedMajorRequiredOSVersion {
+            nudgePrimaryState.hasLoggedMajorRequiredOSVersion = true
+            utilsLog.info("Major required OS version: \(majorRequiredNudgeOSVersion, privacy: .public)")
+        }
         return majorRequiredNudgeOSVersion
     }
 
@@ -257,13 +263,13 @@ struct Utils {
     func getNumberOfDaysBetween() -> Int {
        let currentCal = Calendar.current
        let fromDate = currentCal.startOfDay(for: getCurrentDate())
-       let toDate = currentCal.startOfDay(for: requiredInstallationDate)
+       let toDate = currentCal.startOfDay(for: getRequiredInstallationDate())
        let numberOfDays = currentCal.dateComponents([.day], from: fromDate, to: toDate)
        return numberOfDays.day!
     }
 
     func getNumberOfHoursBetween() -> Int {
-        return Int(requiredInstallationDate.timeIntervalSince(getCurrentDate()) / 3600 )
+        return Int(getRequiredInstallationDate().timeIntervalSince(getCurrentDate()) / 3600 )
     }
 
     func getPatchOSVersion() -> Int {
@@ -365,11 +371,11 @@ struct Utils {
     }
 
     func logRequiredMinimumOSVersion() {
-        nudgeDefaults.set(requiredMinimumOSVersion, forKey: "requiredMinimumOSVersion")
+        nudgeDefaults.set(getRequiredMinimumOSVersion(), forKey: "requiredMinimumOSVersion")
     }
 
     func newNudgeEvent() -> Bool {
-        versionGreaterThan(currentVersion: requiredMinimumOSVersion, newVersion: nudgePrimaryState.userRequiredMinimumOSVersion)
+        versionGreaterThan(currentVersion: getRequiredMinimumOSVersion(), newVersion: nudgePrimaryState.userRequiredMinimumOSVersion)
     }
 
     func openMoreInfo() {
@@ -382,7 +388,7 @@ struct Utils {
     }
 
     func pastRequiredInstallationDate() -> Bool {
-        let pastRequiredInstallationDate = getCurrentDate() > requiredInstallationDate
+        let pastRequiredInstallationDate = getCurrentDate() > getRequiredInstallationDate()
         if !nudgePrimaryState.hasLoggedPastRequiredInstallationDate {
             nudgePrimaryState.hasLoggedPastRequiredInstallationDate = true
             utilsLog.notice("Device pastRequiredInstallationDate: \(pastRequiredInstallationDate, privacy: .public)")
@@ -405,7 +411,10 @@ struct Utils {
 
     func requireMajorUpgrade() -> Bool {
         let requireMajorUpdate = versionGreaterThan(currentVersion: String(getMajorRequiredNudgeOSVersion()), newVersion: String(getMajorOSVersion()))
-        utilsLog.info("Device requireMajorUpgrade: \(requireMajorUpdate, privacy: .public)")
+        if !nudgePrimaryState.hasLoggedRequireMajorUgprade {
+            nudgePrimaryState.hasLoggedRequireMajorUgprade = true
+            utilsLog.info("Device requireMajorUpgrade: \(requireMajorUpdate, privacy: .public)")
+        }
         return requireMajorUpdate
     }
 
@@ -438,7 +447,7 @@ struct Utils {
         if actionButtonPath != nil {
             NSWorkspace.shared.open(URL(string: actionButtonPath!)!)
         } else if requireMajorUpgrade() && majorUpgradeAppPathExists {
-            NSWorkspace.shared.open(URL(fileURLWithPath: majorUpgradeAppPath))
+            NSWorkspace.shared.open(URL(fileURLWithPath: getMajorUpgradeAppPath()))
         } else {
             NSWorkspace.shared.open(URL(fileURLWithPath: "/System/Library/PreferencePanes/SoftwareUpdate.prefPane"))
             // NSWorkspace.shared.open(URL(fileURLWithPath: "x-apple.systempreferences:com.apple.preferences.softwareupdate?client=softwareupdateapp"))

--- a/README.md
+++ b/README.md
@@ -329,13 +329,7 @@ In this example, Nudge will do the following:
         }
       ],
       "requiredInstallationDate": "2021-02-28T00:00:00Z",
-      "requiredMinimumOSVersion": "11.2.1",
-      "targetedOSVersions": [
-        "11.0",
-        "11.0.1",
-        "11.1",
-        "11.2"
-      ]
+      "requiredMinimumOSVersion": "11.2.1"
     }
   ]
 }


### PR DESCRIPTION
- versionRules is an array of dictionary items
- If nudge finds a full match (device running 11.5.2, rule is 11.5.2), it will use the full match rules
- if nudge finds a partial match (device running 11.5.2, rule is 11), it will use the partial match
- if neither are found and there is one of the old v1.0 keys present, it will use them. For v1.1 this can be considered a "fall back"

solution for: https://github.com/macadmins/nudge/issues/157