### PR TITLE
Move targetedOSVersion to targetedOSVersionRule - second attempt at version rules

### DIFF
--- a/Example Assets/com.github.macadmins.Nudge.json
+++ b/Example Assets/com.github.macadmins.Nudge.json
@@ -31,20 +31,7 @@
       "majorUpgradeAppPath": "/Applications/Install macOS Big Sur.app",
       "requiredInstallationDate": "2021-08-28T00:00:00Z",
       "requiredMinimumOSVersion": "11.5.2",
-      "targetedOSVersions": [
-        "11.0",
-        "11.0.1",
-        "11.1",
-        "11.2",
-        "11.2.1",
-        "11.2.2",
-        "11.2.3",
-        "11.3",
-        "11.3.1",
-        "11.4",
-        "11.5",
-        "11.5.1"
-      ]
+      "targetedOSVersionsRule": "default"
     }
   ],
   "userExperience": {

--- a/Example Assets/com.github.macadmins.Nudge.mobileconfig
+++ b/Example Assets/com.github.macadmins.Nudge.mobileconfig
@@ -70,21 +70,8 @@
             <date>2021-08-28T00:00:00Z</date>
             <key>requiredMinimumOSVersion</key>
             <string>11.5.2</string>
-            <key>targetedOSVersions</key>
-            <array>
-              <string>11.0</string>
-              <string>11.0.1</string>
-              <string>11.1</string>
-              <string>11.2</string>
-              <string>11.2.1</string>
-              <string>11.2.2</string>
-              <string>11.2.3</string>
-              <string>11.3</string>
-              <string>11.3.1</string>
-              <string>11.4</string>
-              <string>11.5</string>
-              <string>11.5.1</string>
-            </array>
+            <key>targetedOSVersionsRule</key>
+            <string>default</string>
           </dict>
         </array>
         <key>userExperience</key>

--- a/Nudge/Preferences/PreferencesStructure.swift
+++ b/Nudge/Preferences/PreferencesStructure.swift
@@ -110,7 +110,7 @@ struct OSVersionRequirement: Codable {
     var majorUpgradeAppPath: String?
     var requiredInstallationDate: Date?
     var requiredMinimumOSVersion: String?
-    var targetedOSVersions: [String]?
+    var targetedOSVersionsRule: String?
 }
 
 // MARK: OSVersionRequirement convenience initializers and mutators
@@ -138,7 +138,7 @@ extension OSVersionRequirement {
         self.aboutUpdateURLs = generatedAboutUpdateURLs
         self.majorUpgradeAppPath = fromDictionary["majorUpgradeAppPath"] as? String
         self.requiredMinimumOSVersion = fromDictionary["requiredMinimumOSVersion"] as? String
-        self.targetedOSVersions = fromDictionary["targetedOSVersions"] as? [String]
+        self.targetedOSVersionsRule = fromDictionary["targetedOSVersionsRule"] as? String
     }
 
     init(data: Data) throws {
@@ -162,7 +162,7 @@ extension OSVersionRequirement {
         majorUpgradeAppPath: String?? = nil,
         requiredInstallationDate: Date?? = nil,
         requiredMinimumOSVersion: String?? = nil,
-        targetedOSVersions: [String]?? = nil
+        targetedOSVersionsRule: String?? = nil
     ) -> OSVersionRequirement {
         return OSVersionRequirement(
             aboutUpdateURL: aboutUpdateURL ?? self.aboutUpdateURL,
@@ -170,7 +170,7 @@ extension OSVersionRequirement {
             majorUpgradeAppPath: majorUpgradeAppPath ?? self.majorUpgradeAppPath,
             requiredInstallationDate: requiredInstallationDate ?? self.requiredInstallationDate,
             requiredMinimumOSVersion: requiredMinimumOSVersion ?? self.requiredMinimumOSVersion,
-            targetedOSVersions: targetedOSVersions ?? self.targetedOSVersions
+            targetedOSVersionsRule: targetedOSVersionsRule ?? self.targetedOSVersionsRule
         )
     }
 

--- a/Nudge/UI/ContentView.swift
+++ b/Nudge/UI/ContentView.swift
@@ -18,8 +18,11 @@ class ViewState: ObservableObject {
     @Published var deferRunUntil = nudgeDefaults.object(forKey: "deferRunUntil") as? Date
     @Published var hasLoggedDeferralCountPastThreshhold = false
     @Published var hasLoggedDeferralCountPastThresholdDualQuitButtons = false
+    @Published var hasLoggedMajorOSVersion = false
+    @Published var hasLoggedMajorRequiredOSVersion = false
     @Published var hasLoggedPastRequiredInstallationDate = false
     @Published var hasLoggedRequireDualQuitButtons = false
+    @Published var hasLoggedRequireMajorUgprade = false
     @Published var lastRefreshTime = Utils().getInitialDate()
     @Published var requireDualQuitButtons = false
     @Published var shouldExit = false

--- a/Nudge/Utilities/Preferences.swift
+++ b/Nudge/Utilities/Preferences.swift
@@ -69,6 +69,7 @@ func getOSVersionRequirementsProfile() -> OSVersionRequirement? {
         for (_ , subPreferences) in requirements.enumerated() {
             if subPreferences.targetedOSVersionsRule == currentOSVersion {
                 fullMatch = subPreferences
+            // TODO: For some reason, Utils().getMajorOSVersion() triggers a crash, so I am directly calling ProcessInfo()
             } else if subPreferences.targetedOSVersionsRule == String(ProcessInfo().operatingSystemVersion.majorVersion) {
                 partialMatch = subPreferences
             } else if subPreferences.targetedOSVersionsRule == "default" {
@@ -102,6 +103,7 @@ func getOSVersionRequirementsJSON() -> OSVersionRequirement? {
         for (_ , subPreferences) in requirements.enumerated() {
             if subPreferences.targetedOSVersionsRule == currentOSVersion {
                 fullMatch = subPreferences
+            // TODO: For some reason, Utils().getMajorOSVersion() triggers a crash, so I am directly calling ProcessInfo()
             } else if subPreferences.targetedOSVersionsRule == String(ProcessInfo().operatingSystemVersion.majorVersion) {
                 partialMatch = subPreferences
             } else if subPreferences.targetedOSVersionsRule == "default" {

--- a/Nudge/Utilities/Preferences.swift
+++ b/Nudge/Utilities/Preferences.swift
@@ -53,6 +53,9 @@ func getOptionalFeaturesJSON() -> OptionalFeatures? {
 // Mutate the profile into our required construct and then compare currentOS against targetedOSVersions
 // Even if profile/JSON is installed, return nil if in demo-mode
 func getOSVersionRequirementsProfile() -> OSVersionRequirement? {
+    var fullMatch = OSVersionRequirement()
+    var partialMatch = OSVersionRequirement()
+    var defaultMatch = OSVersionRequirement()
     if Utils().demoModeEnabled() {
         return nil
     }
@@ -63,39 +66,60 @@ func getOSVersionRequirementsProfile() -> OSVersionRequirement? {
         }
     }
     if !requirements.isEmpty {
-        if requirements.count >= 2 {
-            let v1ErrorMsg = "Multiple hashes may result in undefined behavior. Please deploy a single hash for OS enforcement at this time."
-            prefsProfileLog.error("\(v1ErrorMsg, privacy: .public)")
-        }
         for (_ , subPreferences) in requirements.enumerated() {
-            if subPreferences.targetedOSVersions?.contains(currentOSVersion) == true || Utils().versionGreaterThanOrEqual(currentVersion: currentOSVersion, newVersion: subPreferences.requiredMinimumOSVersion ?? "0.0")  {
-                return subPreferences
+            if subPreferences.targetedOSVersionsRule == currentOSVersion {
+                fullMatch = subPreferences
+            } else if subPreferences.targetedOSVersionsRule == String(ProcessInfo().operatingSystemVersion.majorVersion) {
+                partialMatch = subPreferences
+            } else if subPreferences.targetedOSVersionsRule == "default" {
+                defaultMatch = subPreferences
+            } else {
+                defaultMatch = subPreferences
             }
         }
     } else {
         let msg = "profile osVersionRequirements key is empty"
         prefsProfileLog.info("\(msg, privacy: .public)")
     }
+    if fullMatch.requiredMinimumOSVersion != nil {
+        return fullMatch }
+    else if partialMatch.requiredMinimumOSVersion != nil {
+        return partialMatch
+    } else if defaultMatch.requiredMinimumOSVersion != nil {
+        return defaultMatch
+    }
     return nil
 }
 // Loop through JSON osVersionRequirements preferences and then compare currentOS against targetedOSVersions
 func getOSVersionRequirementsJSON() -> OSVersionRequirement? {
+    var fullMatch = OSVersionRequirement()
+    var partialMatch = OSVersionRequirement()
+    var defaultMatch = OSVersionRequirement()
     if Utils().demoModeEnabled() {
         return nil
     }
     if let requirements = nudgeJSONPreferences?.osVersionRequirements {
-        if requirements.count >= 2 {
-            let v1ErrorMsg = "Multiple hashes may result in undefined behavior. Please deploy a single hash for OS enforcement at this time."
-            prefsJSONLog.error("\(v1ErrorMsg, privacy: .public)")
-        }
         for (_ , subPreferences) in requirements.enumerated() {
-            if subPreferences.targetedOSVersions?.contains(currentOSVersion) == true || Utils().versionGreaterThanOrEqual(currentVersion: currentOSVersion, newVersion: subPreferences.requiredMinimumOSVersion ?? "0.0") {
-                return subPreferences
+            if subPreferences.targetedOSVersionsRule == currentOSVersion {
+                fullMatch = subPreferences
+            } else if subPreferences.targetedOSVersionsRule == String(ProcessInfo().operatingSystemVersion.majorVersion) {
+                partialMatch = subPreferences
+            } else if subPreferences.targetedOSVersionsRule == "default" {
+                defaultMatch = subPreferences
+            } else if subPreferences.targetedOSVersionsRule == nil {
+                defaultMatch = subPreferences
             }
         }
     } else {
         let msg = "json osVersionRequirements key is empty"
         prefsJSONLog.info("\(msg, privacy: .public)")
+    }
+    if fullMatch.requiredMinimumOSVersion != nil {
+        return fullMatch }
+    else if partialMatch.requiredMinimumOSVersion != nil {
+        return partialMatch
+    } else if defaultMatch.requiredMinimumOSVersion != nil {
+        return defaultMatch
     }
     return nil
 }

--- a/Nudge/Utilities/Preferences.swift
+++ b/Nudge/Utilities/Preferences.swift
@@ -83,8 +83,8 @@ func getOSVersionRequirementsProfile() -> OSVersionRequirement? {
         prefsProfileLog.info("\(msg, privacy: .public)")
     }
     if fullMatch.requiredMinimumOSVersion != nil {
-        return fullMatch }
-    else if partialMatch.requiredMinimumOSVersion != nil {
+        return fullMatch
+    } else if partialMatch.requiredMinimumOSVersion != nil {
         return partialMatch
     } else if defaultMatch.requiredMinimumOSVersion != nil {
         return defaultMatch
@@ -117,8 +117,8 @@ func getOSVersionRequirementsJSON() -> OSVersionRequirement? {
         prefsJSONLog.info("\(msg, privacy: .public)")
     }
     if fullMatch.requiredMinimumOSVersion != nil {
-        return fullMatch }
-    else if partialMatch.requiredMinimumOSVersion != nil {
+        return fullMatch
+    } else if partialMatch.requiredMinimumOSVersion != nil {
         return partialMatch
     } else if defaultMatch.requiredMinimumOSVersion != nil {
         return defaultMatch

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -192,14 +192,20 @@ struct Utils {
 
     func getMajorOSVersion() -> Int {
         let MajorOSVersion = ProcessInfo().operatingSystemVersion.majorVersion
-        utilsLog.info("OS Version: \(MajorOSVersion, privacy: .public)")
+        if !nudgePrimaryState.hasLoggedMajorOSVersion {
+            nudgePrimaryState.hasLoggedMajorOSVersion = true
+            utilsLog.info("OS Version: \(MajorOSVersion, privacy: .public)")
+        }
         return MajorOSVersion
     }
 
     func getMajorRequiredNudgeOSVersion() -> Int {
         let parts = requiredMinimumOSVersion.split(separator: ".", omittingEmptySubsequences: false)
         let majorRequiredNudgeOSVersion = Int((parts[0]))!
-        utilsLog.info("Major required OS version: \(majorRequiredNudgeOSVersion, privacy: .public)")
+        if !nudgePrimaryState.hasLoggedMajorRequiredOSVersion {
+            nudgePrimaryState.hasLoggedMajorRequiredOSVersion = true
+            utilsLog.info("Major required OS version: \(majorRequiredNudgeOSVersion, privacy: .public)")
+        }
         return majorRequiredNudgeOSVersion
     }
 
@@ -405,7 +411,10 @@ struct Utils {
 
     func requireMajorUpgrade() -> Bool {
         let requireMajorUpdate = versionGreaterThan(currentVersion: String(getMajorRequiredNudgeOSVersion()), newVersion: String(getMajorOSVersion()))
-        utilsLog.info("Device requireMajorUpgrade: \(requireMajorUpdate, privacy: .public)")
+        if !nudgePrimaryState.hasLoggedRequireMajorUgprade {
+            nudgePrimaryState.hasLoggedRequireMajorUgprade = true
+            utilsLog.info("Device requireMajorUpgrade: \(requireMajorUpdate, privacy: .public)")
+        }
         return requireMajorUpdate
     }
 

--- a/Schema/jamf/com.github.macadmins.Nudge.json
+++ b/Schema/jamf/com.github.macadmins.Nudge.json
@@ -108,7 +108,7 @@
 						"type": "string"
 					},
 					"targetedOSVersions": {
-						"description": "The versions of macOS that require a security update. You can specify single version or multiple versions.",
+						"description": "The versions of macOS that require a security update. You can specify single version or multiple versions. This key is only used with Nudge v1.0 and will not be honored in v1.1",
 						"type": "array",
 						"items": {
 							"options": {
@@ -119,7 +119,16 @@
 							"type": "string",
 							"title": "targetedOSVersion"
 						}
-					}
+					},
+					"targetedOSVersionsRule": {
+						"description": "The OS string rule for targeting nudge events. You can target with \"default\", the full OS version (example: \"11.5.1\"). or the major OS version (example: \"11\"). This key is only used with Nudge v1.1 and will not be honored in v1.0",
+						"options": {
+							"inputAttributes": {
+								"placeholder": "default"
+							}
+						},
+						"type": "string"
+					},
 				}
 			}
 		},


### PR DESCRIPTION
fully addresses: https://github.com/macadmins/nudge/issues/157
- targetedOSVersionRule is a simple string with targetedOSVersion fully removed
- If nudge finds a full match (device running 11.5.2, rule is 11.5.2), it will use the full match rules
- if nudge finds a partial match (device running 11.5.2, rule is 11), it will use the partial match
- if neither are found and there is a dictionary missing the targetedOSVersionsRule key, or the key has a value of "default", it will use them. This allows forward/backward compatibility with v1.0

Example JSON:

```json
{
  "osVersionRequirements": [
    {
      "aboutUpdateURL": "https://apple.com",
      "requiredInstallationDate": "2021-07-30T00:00:00Z",
      "requiredMinimumOSVersion": "11.5.2"
    },
    {
      "aboutUpdateURL": "https://apple.com",
      "requiredInstallationDate": "2021-07-30T00:00:00Z",
      "requiredMinimumOSVersion": "11.5.3",
      "targetedOSVersionsRule": "11.5.2"
    },
    {
      "aboutUpdateURL": "https://apple.com",
      "requiredInstallationDate": "2021-07-30T00:00:00Z",
      "requiredMinimumOSVersion": "11.5.4",
      "targetedOSVersionsRule": "11"
    }
  ]
}
```

or you could do
```json
{
  "osVersionRequirements": [
    {
      "aboutUpdateURL": "https://apple.com",
      "requiredInstallationDate": "2021-07-30T00:00:00Z",
      "requiredMinimumOSVersion": "11.5.2",
      "targetedOSVersionsRule": "default"
    },
    {
      "aboutUpdateURL": "https://apple.com",
      "requiredInstallationDate": "2021-07-30T00:00:00Z",
      "requiredMinimumOSVersion": "11.5.3",
      "targetedOSVersionsRule": "11.5.2"
    },
    {
      "aboutUpdateURL": "https://apple.com",
      "requiredInstallationDate": "2021-07-30T00:00:00Z",
      "requiredMinimumOSVersion": "11.5.4",
      "targetedOSVersionsRule": "11"
    }
  ]
}
```

The main benefit of this approach, is we do not have to repeat any of the key structure compared to https://github.com/macadmins/nudge/pull/224.

I also anticipated that we would have to clone _all_ keys from OSVersionRequirements as people may want custom `aboutUpdateURL` or `aboutUpdateURLs` and this would be a constantly moving target