### PR TITLE
DeferView triggers userInitiatedExit() instead of the dismissal sheet

### DIFF
--- a/Nudge/UI/DeferView.swift
+++ b/Nudge/UI/DeferView.swift
@@ -59,7 +59,7 @@ struct DeferView: View {
                     viewObserved.userDeferrals = viewObserved.userSessionDeferrals + viewObserved.userQuitDeferrals
                     Utils().logUserQuitDeferrals()
                     Utils().logUserDeferrals()
-                    self.presentationMode.wrappedValue.dismiss()
+                    Utils().userInitiatedExit()
                 } label: {
                     Text("Defer")
                         .frame(minWidth: 35)

--- a/Nudge/UI/SimpleMode/SimpleMode.swift
+++ b/Nudge/UI/SimpleMode/SimpleMode.swift
@@ -231,9 +231,6 @@ struct SimpleMode: View {
                         }
                         .frame(maxHeight: 30)
                         .sheet(isPresented: $showDeferView) {
-                            if viewObserved.shouldExit {
-                                Utils().userInitiatedExit()
-                            }
                         } content: {
                             DeferView(viewObserved: viewObserved)
                         }

--- a/Nudge/UI/StandardMode/RightSide.swift
+++ b/Nudge/UI/StandardMode/RightSide.swift
@@ -269,9 +269,6 @@ struct StandardModeRightSide: View {
                             }
                         }
                         .sheet(isPresented: $showDeferView) {
-                            if viewObserved.shouldExit {
-                                Utils().userInitiatedExit()
-                            }
                         } content: {
                             DeferView(viewObserved: viewObserved)
                         }


### PR DESCRIPTION
Addresses: https://github.com/macadmins/nudge/issues/226

This code didn't work last week, but it was due to my use of AppKit.NSApp.terminate(nil). When I moved to exit(0), this allowed this code to actually work. I just didn't know about it.

Testing was kind of crappy, but I took the nudge.app debug application and sent it over via SSH to the M1 11.4 machine. Nudge successfully closed. I don't think I'll fully know, until I merge this and create a new release.