### PR TITLE
Fixes mismatched tags on example MobileConfig

### DIFF
--- a/Example Assets/com.github.macadmins.Nudge.mobileconfig
+++ b/Example Assets/com.github.macadmins.Nudge.mobileconfig
@@ -108,7 +108,7 @@
         <key>userInterface</key>
         <dict>
           <key>actionButtonPath</key>
-          <string>munki://updates</key>
+          <string>munki://updates</string>
           <key>fallbackLanguage</key>
           <string>en</string>
           <key>forceFallbackLanguage</key>


### PR DESCRIPTION
Fixes a mismatched XML tag on the example profile.