### PR TITLE
Update createImageData to be able to accept http(s) as a source

### DIFF
--- a/Nudge/UI/Common/CompanyLogo.swift
+++ b/Nudge/UI/Common/CompanyLogo.swift
@@ -28,21 +28,11 @@ struct CompanyLogo: View {
         let companyLogoPath = Utils().getCompanyLogoPath(darkMode: darkMode)
         
         // Company Logo
-        Group {
-            if FileManager.default.fileExists(atPath: companyLogoPath) {
-                Image(nsImage: Utils().createImageData(fileImagePath: companyLogoPath))
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .scaledToFit()
-                    .frame(width: logoWidth, height: logoHeight)
-            } else {
-                Image(systemName: "applelogo")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .scaledToFit()
-                    .frame(width: logoWidth, height: logoHeight)
-            }
-        }
+        Image(nsImage: Utils().createImageData(fileImagePath: companyLogoPath))
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .scaledToFit()
+            .frame(width: logoWidth, height: logoHeight)
     }
 }
 

--- a/Nudge/UI/StandardMode/RightSide.swift
+++ b/Nudge/UI/StandardMode/RightSide.swift
@@ -28,7 +28,7 @@ struct StandardModeRightSide: View {
     var body: some View {
         let darkMode = colorScheme == .dark
         let screenShotPath = Utils().getScreenShotPath(darkMode: darkMode)
-        let screenShotExists = FileManager.default.fileExists(atPath: screenShotPath)
+        let screenShotExists = Utils().pathIsFileOrURL(path: screenShotPath)
         // Right side of Nudge
         VStack {
             Spacer()
@@ -126,7 +126,7 @@ struct StandardModeRightSide: View {
                         Button {
                             self.showSSDetail.toggle()
                         } label: {
-                            Image(nsImage: Utils().createImageData(fileImagePath: screenShotPath))
+                            Image(nsImage: Utils().createImageData(fileImagePath: screenShotPath, returnErrorImage: false))
                                 .resizable()
                                 .scaledToFit()
                                 .aspectRatio(contentMode: .fit)

--- a/Nudge/UI/StandardMode/ScreenShotZoom.swift
+++ b/Nudge/UI/StandardMode/ScreenShotZoom.swift
@@ -44,31 +44,24 @@ struct ScreenShotZoom: View {
             
             HStack {
                 Button(action: {self.presentationMode.wrappedValue.dismiss()}, label: {
-                    if FileManager.default.fileExists(atPath: screenShotPath) {
-                        Image(nsImage: Utils().createImageData(fileImagePath: screenShotPath))
-                            .resizable()
-                            .scaledToFit()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(maxHeight: 512)
-                    } else {
-                        Image("CompanyScreenshotIcon")
-                            .resizable()
-                            .scaledToFit()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(maxHeight: 512)
-                    }
+                    Image(nsImage: Utils().createImageData(fileImagePath: screenShotPath, returnErrorImage: false))
+                        .resizable()
+                        .scaledToFit()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(maxHeight: 512)
                 }
                 )
                     .buttonStyle(.plain)
-                .help("Click to close".localized(desiredLanguage: getDesiredLanguage()))
-                .onHover { inside in
-                    if inside {
-                        NSCursor.pointingHand.push()
-                    } else {
-                        NSCursor.pop()
+                    .help("Click to close".localized(desiredLanguage: getDesiredLanguage()))
+                    .onHover { inside in
+                        if inside {
+                            NSCursor.pointingHand.push()
+                        } else {
+                            NSCursor.pop()
+                        }
                     }
                 }
-            }
+            
             // Vertically align Screenshot to center
             Spacer()
         }

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -81,11 +81,26 @@ struct Utils {
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
         return dateFormatter.date(from: dateString) ?? Date()
     }
-
-    func createImageData(fileImagePath: String) -> NSImage {
+    
+    func createImageData(fileImagePath: String, imgWidth: CGFloat? = .infinity, imgHeight: CGFloat? = .infinity) -> NSImage {
+        // accept image as local file path or as URL and return NSImage
+        // can pass in width and height as optional values otherwise return the image as is.
+        
         utilsLog.debug("Creating image path for \(fileImagePath, privacy: .public)")
-        let urlPath = NSURL(fileURLWithPath: fileImagePath)
+        
+        // need to declare literal empty string first otherwise the runtime whinges about an NSURL instance with an empty URL string. I know!
+        var urlPath = NSURL(string: "")!
         var imageData = NSData()
+        
+        // checking for anything starting with http
+        // which means we create the image from URL directly not as fileURL
+        if fileImagePath.hasPrefix("http") {
+            urlPath = NSURL(string: fileImagePath)!
+        } else {
+            urlPath = NSURL(fileURLWithPath: fileImagePath)
+        }
+          
+        // wrap everything in a try block.IF the URL or filepath is unreadable then return a default
         do {
             imageData = try NSData(contentsOf: urlPath as URL)
         } catch {
@@ -93,7 +108,16 @@ struct Utils {
             let errorImageConfig = NSImage.SymbolConfiguration(pointSize: 200, weight: .regular)
             return NSImage(systemSymbolName: "applelogo", accessibilityDescription: nil)!.withSymbolConfiguration(errorImageConfig)!
         }
-        return NSImage(data: imageData as Data)!
+        
+        // We have our image data - time to process it and return with specified dimensions
+        let image : NSImage = NSImage(data: imageData as Data)!
+        
+        if let rep = NSImage(data: imageData as Data)!
+            .bestRepresentation(for: NSRect(x: 0, y: 0, width: imgWidth!, height: imgHeight!), context: nil, hints: nil) {
+            image.size = rep.size
+            image.addRepresentation(rep)
+        }
+        return image
     }
 
     func debugUIModeEnabled() -> Bool {


### PR DESCRIPTION
Drop in replacement that should allow for http(s) URL's to be useable as a resource for displaying data such as screenshots, logo's etc as an alternative to deploying these resources to endpoints directly.

Also support optional parameters to return an image of certain size although this doesn't reduce the memory footprint as the full size is still represented in memory. (SwiftUI does a decent job of resizing and keeping the data manageable). Tested up to 8k image which increased memory footprint by ~40mb. 