### PR TITLE
Padding for AdditionalInfoButton 

### DIFF
--- a/Nudge/UI/SimpleMode/SimpleMode.swift
+++ b/Nudge/UI/SimpleMode/SimpleMode.swift
@@ -26,6 +26,7 @@ struct SimpleMode: View {
         VStack {
             // display the (?) info button
             AdditionalInfoButton()
+                .padding(3)
 
             VStack(alignment: .center, spacing: 10) {
                 Spacer()

--- a/Nudge/UI/StandardMode/LeftSide.swift
+++ b/Nudge/UI/StandardMode/LeftSide.swift
@@ -27,6 +27,7 @@ struct StandardModeLeftSide: View {
             VStack(alignment: .center, spacing: 20) {
                 // display the (?) info button
                 AdditionalInfoButton()
+                    .padding(3)
                 
                 // Company Logo
                 CompanyLogo(width: logoWidth, height: logoHeight)


### PR DESCRIPTION
Added padding for AdditionalInfoButton so it's not hugging the edge of the window.

for issue https://github.com/macadmins/nudge/issues/246

Before:
<img width="86" alt="Screen Shot 2021-09-05 at 2 57 44 pm" src="https://user-images.githubusercontent.com/3598965/132115814-9bc41f5a-fda0-4fca-a701-4f5e9e3bfcbe.png">

After:
<img width="114" alt="Screen Shot 2021-09-04 at 8 10 06 pm" src="https://user-images.githubusercontent.com/3598965/132115778-29f89af6-13ca-45a2-b807-7cddd264eb42.png">

