### PR TITLE
Fix layout of the "Defer" date picker view

### DIFF
--- a/Nudge/UI/Common/DeferView.swift
+++ b/Nudge/UI/Common/DeferView.swift
@@ -38,35 +38,42 @@ struct DeferView: View {
                         NSCursor.pop()
                     }
                 }
-                .frame(width: 30, height: 30)
+                // pulls the button away from the very edge of the view. Value of 4 seems a nice distance
+                .padding(4)
                 Spacer()
             }
-            // We have two DatePickers because DatePicker is non-ideal
-            DatePicker("", selection: $nudgeCustomEventDate, in: limitRange)
-                .datePickerStyle(.graphical)
-                .labelsHidden()
-                .frame(width: 280, height: 140, alignment: .center)
-            DatePicker("", selection: $nudgeCustomEventDate, in: limitRange, displayedComponents: [.hourAndMinute])
-                .labelsHidden()
-                .frame(maxWidth: 100)
-            Divider()
-            HStack {
-                Button {
-                    nudgeDefaults.set(nudgeCustomEventDate, forKey: "deferRunUntil")
-                    userHasClickedDeferralQuitButton(deferralTime: nudgeCustomEventDate)
-                    viewObserved.shouldExit = true
-                    viewObserved.userQuitDeferrals += 1
-                    viewObserved.userDeferrals = viewObserved.userSessionDeferrals + viewObserved.userQuitDeferrals
-                    Utils().logUserQuitDeferrals()
-                    Utils().logUserDeferrals()
-                    Utils().userInitiatedExit()
-                } label: {
-                    Text("Defer")
-                        .frame(minWidth: 35)
-                }
+            
+            VStack() {
+                // We have two DatePickers because DatePicker is non-ideal
+                DatePicker("", selection: $nudgeCustomEventDate, in: limitRange)
+                    .datePickerStyle(.graphical)
+                    .labelsHidden()
+                DatePicker("", selection: $nudgeCustomEventDate, in: limitRange, displayedComponents: [.hourAndMinute])
+                    .labelsHidden()
+                    .frame(maxWidth: 100)
             }
+            // make space left and right of the stack
+            .padding(.leading, 30)
+            .padding(.trailing, 30)
+            
+            Divider()
+            
+            Button {
+                nudgeDefaults.set(nudgeCustomEventDate, forKey: "deferRunUntil")
+                userHasClickedDeferralQuitButton(deferralTime: nudgeCustomEventDate)
+                viewObserved.shouldExit = true
+                viewObserved.userQuitDeferrals += 1
+                viewObserved.userDeferrals = viewObserved.userSessionDeferrals + viewObserved.userQuitDeferrals
+                Utils().logUserQuitDeferrals()
+                Utils().logUserDeferrals()
+                Utils().userInitiatedExit()
+            } label: {
+                Text("Defer")
+                    .frame(minWidth: 35)
+            }
+            // a bit of space at the bottom to raise the Defer button away from the very edge
+            .padding(.bottom, 10)
         }
-        .frame(width: 350, height: 275)
     }
     var limitRange: ClosedRange<Date> {
         if viewObserved.daysRemaining > 0 {

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -81,26 +81,11 @@ struct Utils {
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
         return dateFormatter.date(from: dateString) ?? Date()
     }
-    
-    func createImageData(fileImagePath: String, imgWidth: CGFloat? = .infinity, imgHeight: CGFloat? = .infinity) -> NSImage {
-        // accept image as local file path or as URL and return NSImage
-        // can pass in width and height as optional values otherwise return the image as is.
-        
+
+    func createImageData(fileImagePath: String) -> NSImage {
         utilsLog.debug("Creating image path for \(fileImagePath, privacy: .public)")
-        
-        // need to declare literal empty string first otherwise the runtime whinges about an NSURL instance with an empty URL string. I know!
-        var urlPath = NSURL(string: "")!
+        let urlPath = NSURL(fileURLWithPath: fileImagePath)
         var imageData = NSData()
-        
-        // checking for anything starting with http
-        // which means we create the image from URL directly not as fileURL
-        if fileImagePath.hasPrefix("http") {
-            urlPath = NSURL(string: fileImagePath)!
-        } else {
-            urlPath = NSURL(fileURLWithPath: fileImagePath)
-        }
-          
-        // wrap everything in a try block.IF the URL or filepath is unreadable then return a default
         do {
             imageData = try NSData(contentsOf: urlPath as URL)
         } catch {
@@ -108,16 +93,7 @@ struct Utils {
             let errorImageConfig = NSImage.SymbolConfiguration(pointSize: 200, weight: .regular)
             return NSImage(systemSymbolName: "applelogo", accessibilityDescription: nil)!.withSymbolConfiguration(errorImageConfig)!
         }
-        
-        // We have our image data - time to process it and return with specified dimensions
-        let image : NSImage = NSImage(data: imageData as Data)!
-        
-        if let rep = NSImage(data: imageData as Data)!
-            .bestRepresentation(for: NSRect(x: 0, y: 0, width: imgWidth!, height: imgHeight!), context: nil, hints: nil) {
-            image.size = rep.size
-            image.addRepresentation(rep)
-        }
-        return image
+        return NSImage(data: imageData as Data)!
     }
 
     func debugUIModeEnabled() -> Bool {

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -81,11 +81,26 @@ struct Utils {
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
         return dateFormatter.date(from: dateString) ?? Date()
     }
-
-    func createImageData(fileImagePath: String) -> NSImage {
+    
+    func createImageData(fileImagePath: String, imgWidth: CGFloat? = .infinity, imgHeight: CGFloat? = .infinity) -> NSImage {
+        // accept image as local file path or as URL and return NSImage
+        // can pass in width and height as optional values otherwise return the image as is.
+        
         utilsLog.debug("Creating image path for \(fileImagePath, privacy: .public)")
-        let urlPath = NSURL(fileURLWithPath: fileImagePath)
+        
+        // need to declare literal empty string first otherwise the runtime whinges about an NSURL instance with an empty URL string. I know!
+        var urlPath = NSURL(string: "")!
         var imageData = NSData()
+        
+        // checking for anything starting with http
+        // which means we create the image from URL directly not as fileURL
+        if fileImagePath.hasPrefix("http") {
+            urlPath = NSURL(string: fileImagePath)!
+        } else {
+            urlPath = NSURL(fileURLWithPath: fileImagePath)
+        }
+          
+        // wrap everything in a try block.IF the URL or filepath is unreadable then return a default
         do {
             imageData = try NSData(contentsOf: urlPath as URL)
         } catch {
@@ -93,7 +108,16 @@ struct Utils {
             let errorImageConfig = NSImage.SymbolConfiguration(pointSize: 200, weight: .regular)
             return NSImage(systemSymbolName: "applelogo", accessibilityDescription: nil)!.withSymbolConfiguration(errorImageConfig)!
         }
-        return NSImage(data: imageData as Data)!
+        
+        // We have our image data - time to process it and return with specified dimensions
+        let image : NSImage = NSImage(data: imageData as Data)!
+        
+        if let rep = NSImage(data: imageData as Data)!
+            .bestRepresentation(for: NSRect(x: 0, y: 0, width: imgWidth!, height: imgHeight!), context: nil, hints: nil) {
+            image.size = rep.size
+            image.addRepresentation(rep)
+        }
+        return image
     }
 
     func debugUIModeEnabled() -> Bool {


### PR DESCRIPTION
Part 2 of fixing the issues raised in https://github.com/macadmins/nudge/issues/246

A little more work but brings the view declaration into line with how other views are defined with stronger reliance on letting SwiftUI do the layout for the most part

Before:
<img width="370" alt="defer-before" src="https://user-images.githubusercontent.com/3598965/132301448-3fd9fe2d-6613-4fbc-9411-aa8acdf64e3d.png">

After:
<img width="358" alt="Screen Shot 2021-09-07 at 5 06 27 pm" src="https://user-images.githubusercontent.com/3598965/132301489-c2b8db85-b283-4b27-b5bf-f24faf0545f5.png">

