### PR TITLE
remove unsafe check for big sur 11.3 and lower

### DIFF
--- a/Nudge/UI/Main.swift
+++ b/Nudge/UI/Main.swift
@@ -63,19 +63,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if Utils().demoModeEnabled() {
             return
         }
-        if Utils().unsafeSoftwareUpdate() {
-            // Temporary workaround for Big Sur bug
-            let msg = "Due to a bug in Big Sur 11.3 and lower, Nudge cannot reliably use /usr/sbin/softwareupdate to download updates. See https://openradar.appspot.com/radar?id=4987491098558464 for more information regarding this issue."
-            softwareupdateDownloadLog.warning("\(msg, privacy: .public)")
-            return
-        } else {
-            if asyncronousSoftwareUpdate && Utils().requireMajorUpgrade() == false {
-                DispatchQueue(label: "nudge-su", attributes: .concurrent).asyncAfter(deadline: .now(), execute: {
-                    SoftwareUpdate().Download()
-                })
-            } else {
+
+        if asyncronousSoftwareUpdate && Utils().requireMajorUpgrade() == false {
+            DispatchQueue(label: "nudge-su", attributes: .concurrent).asyncAfter(deadline: .now(), execute: {
                 SoftwareUpdate().Download()
-            }
+            })
+        } else {
+            SoftwareUpdate().Download()
         }
     }
 

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -473,15 +473,6 @@ struct Utils {
         return simpleModeEnabled
     }
 
-    func unsafeSoftwareUpdate() -> Bool {
-        let runningUnsafeSoftwareUpdateOSVersion = versionLessThan(currentVersion: currentOSVersion, newVersion: "11.4")
-        if runningUnsafeSoftwareUpdateOSVersion {
-            return true
-        } else {
-            return false
-        }
-    }
-
     func updateDevice(userClicked: Bool = true) {
         if userClicked {
             let msg = "User clicked updateDevice"


### PR DESCRIPTION
Since we are no longer using `softwareupdate --download --all` this bug may no longer be triggering. This needs to be tested but I think it will work.