### PR TITLE
add preference to skip the softwareupdate process.

### DIFF
--- a/Nudge/Preferences/DefaultPreferencesNudge.swift
+++ b/Nudge/Preferences/DefaultPreferencesNudge.swift
@@ -19,6 +19,7 @@ let customAcceptableApplicationBundleIDs = optionalFeaturesProfile?["acceptableA
 let asynchronousSoftwareUpdate = optionalFeaturesProfile?["asynchronousSoftwareUpdate"] as? Bool ?? optionalFeaturesJSON?.asynchronousSoftwareUpdate ?? true
 let attemptToFetchMajorUpgrade = optionalFeaturesProfile?["attemptToFetchMajorUpgrade"] as? Bool ?? optionalFeaturesJSON?.attemptToFetchMajorUpgrade ?? true
 let enforceMinorUpdates = optionalFeaturesProfile?["enforceMinorUpdates"] as? Bool ?? optionalFeaturesJSON?.enforceMinorUpdates ?? true
+let disableSoftwareUpdateWorkflow = optionalFeaturesProfile?["disableSoftwareUpdateWorkflow"] as? Bool ?? optionalFeaturesJSON?.disableSoftwareUpdateWorkflow ?? false
 
 // osVersionRequirements
 let osVersionRequirementsProfile = getOSVersionRequirementsProfile()

--- a/Nudge/Preferences/PreferencesStructure.swift
+++ b/Nudge/Preferences/PreferencesStructure.swift
@@ -59,7 +59,11 @@ extension NudgePreferences {
 // MARK: - OptionalFeatures
 struct OptionalFeatures: Codable {
     var acceptableApplicationBundleIDs: [String]?
-    var aggressiveUserExperience, asynchronousSoftwareUpdate, attemptToFetchMajorUpgrade, enforceMinorUpdates: Bool?
+    var aggressiveUserExperience,
+        asynchronousSoftwareUpdate,
+        attemptToFetchMajorUpgrade,
+        disableSoftwareUpdateWorkflow,
+        enforceMinorUpdates: Bool?
 }
 
 // MARK: OptionalFeatures convenience initializers and mutators
@@ -85,6 +89,7 @@ extension OptionalFeatures {
         aggressiveUserExperience: Bool?? = nil,
         asynchronousSoftwareUpdate: Bool?? = nil,
         attemptToFetchMajorUpgrade: Bool?? = nil,
+        disableSoftwareUpdateWorkflow: Bool?? = nil,
         enforceMinorUpdates: Bool?? = nil
     ) -> OptionalFeatures {
         return OptionalFeatures(
@@ -92,6 +97,7 @@ extension OptionalFeatures {
             aggressiveUserExperience: aggressiveUserExperience ?? self.aggressiveUserExperience,
             asynchronousSoftwareUpdate: asynchronousSoftwareUpdate ?? self.asynchronousSoftwareUpdate,
             attemptToFetchMajorUpgrade: attemptToFetchMajorUpgrade ?? self.attemptToFetchMajorUpgrade,
+            disableSoftwareUpdateWorkflow: disableSoftwareUpdateWorkflow ?? self.disableSoftwareUpdateWorkflow,
             enforceMinorUpdates: enforceMinorUpdates ?? self.enforceMinorUpdates
         )
     }

--- a/Nudge/Utilities/SoftwareUpdate.swift
+++ b/Nudge/Utilities/SoftwareUpdate.swift
@@ -113,6 +113,10 @@ class SoftwareUpdate {
                     softwareupdateListLog.notice("\(msg, privacy: .public)")
             }
         } else {
+            if disableSoftwareUpdateWorkflow {
+                let msg = "Skip running softwareupdate because it's disabled by a preference."
+                uiLog.info("\(msg, privacy: .public)")
+            }
             let softwareupdateList = self.List()
             var updateLabel = ""
             for update in softwareupdateList.components(separatedBy: "\n") {


### PR DESCRIPTION
When neverRunSoftwareUpdate is true, nudge will not attempt to run
the softwareupdate process. Defaults to false.

This option is useful in cases where running `softwareupdate` causes other
issues for OS updates, or if the organization is already using a different
methods to start the download of an update.

resolves #300