### PR TITLE
Added `importantTextColor` as an option

### DIFF
--- a/Example Assets/com.github.macadmins.Nudge.json
+++ b/Example Assets/com.github.macadmins.Nudge.json
@@ -62,6 +62,7 @@
     "showDeferralCount": true,
     "simpleMode": false,
     "singleQuitButton": false,
+    "importantTextColor": "red",
     "updateElements": [
       {
         "_language": "en",

--- a/Example Assets/com.github.macadmins.Nudge.mobileconfig
+++ b/Example Assets/com.github.macadmins.Nudge.mobileconfig
@@ -129,6 +129,8 @@
           <false/>
           <key>singleQuitButton</key>
           <false/>
+          <key>importantTextColor</key>
+          <string>red</string>
           <key>updateElements</key>
           <array>
             <dict>

--- a/Nudge/Preferences/DefaultPreferencesNudge.swift
+++ b/Nudge/Preferences/DefaultPreferencesNudge.swift
@@ -61,6 +61,7 @@ let iconDarkPath = userInterfaceProfile?["iconDarkPath"] as? String ?? userInter
 let iconLightPath = userInterfaceProfile?["iconLightPath"] as? String ?? userInterfaceJSON?.iconLightPath ?? ""
 let screenShotDarkPath = userInterfaceProfile?["screenShotDarkPath"] as? String ?? userInterfaceJSON?.screenShotDarkPath ?? ""
 let screenShotLightPath = userInterfaceProfile?["screenShotLightPath"] as? String ?? userInterfaceJSON?.screenShotLightPath ?? ""
+let importantTextColor = userInterfaceProfile?["importantTextColor"] as? String ?? userInterfaceJSON?.importantTextColor ?? "red"
 let actionButtonText = userInterfaceUpdateElementsProfile?["actionButtonText"] as? String ?? userInterfaceUpdateElementsJSON?.actionButtonText ?? "Update Device".localized(desiredLanguage: getDesiredLanguage())
 let informationButtonText = userInterfaceUpdateElementsProfile?["informationButtonText"] as? String ?? userInterfaceUpdateElementsJSON?.informationButtonText ?? "More Info".localized(desiredLanguage: getDesiredLanguage())
 let mainContentHeader = userInterfaceUpdateElementsProfile?["mainContentHeader"] as? String ?? userInterfaceUpdateElementsJSON?.mainContentHeader ?? "Your device will restart during this update".localized(desiredLanguage: getDesiredLanguage())

--- a/Nudge/Preferences/PreferencesStructure.swift
+++ b/Nudge/Preferences/PreferencesStructure.swift
@@ -316,6 +316,7 @@ struct UserInterface: Codable {
     var iconDarkPath, iconLightPath, screenShotDarkPath, screenShotLightPath: String?
     var showDeferralCount, simpleMode, singleQuitButton: Bool?
     var updateElements: [UpdateElement]?
+    var importantTextColor: String?
 }
 
 // MARK: UserInterface convenience initializers and mutators
@@ -348,7 +349,8 @@ extension UserInterface {
         showDeferralCount: Bool?? = nil,
         simpleMode: Bool?? = nil,
         singleQuitButton: Bool?? = nil,
-        updateElements: [UpdateElement]?? = nil
+        updateElements: [UpdateElement]?? = nil,
+        importantTextColor: String?? = nil
     ) -> UserInterface {
         return UserInterface(
             actionButtonPath: actionButtonPath ?? self.actionButtonPath,
@@ -362,7 +364,8 @@ extension UserInterface {
             showDeferralCount: showDeferralCount ?? self.showDeferralCount,
             simpleMode: simpleMode ?? self.simpleMode,
             singleQuitButton: singleQuitButton ?? self.simpleMode,
-            updateElements: updateElements ?? self.updateElements
+            updateElements: updateElements ?? self.updateElements,
+            importantTextColor: importantTextColor ?? self.importantTextColor
         )
     }
 

--- a/Nudge/UI/StandardMode/RightSide.swift
+++ b/Nudge/UI/StandardMode/RightSide.swift
@@ -57,6 +57,7 @@ struct StandardModeRightSide: View {
             }
             .padding(.leading, contentWidthPadding)
             .padding(.trailing, contentWidthPadding)
+            .padding(.bottom, 10)
             
             // I'm kind of impressed with myself
             VStack {

--- a/Nudge/UI/StandardMode/RightSide.swift
+++ b/Nudge/UI/StandardMode/RightSide.swift
@@ -100,7 +100,7 @@ struct StandardModeRightSide: View {
                         Text(mainContentNote)
                             .font(.callout)
                             .fontWeight(.bold)
-                            .foregroundColor(Color.red)
+                            .foregroundColor(Utils().stringToColour(importantTextColor))
                         Spacer()
                     }
 

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -21,6 +21,12 @@ extension String {
     }
 }
 
+extension StringProtocol {
+    subscript(offset: Int) -> Character {
+        self[index(startIndex, offsetBy: offset)]
+    }
+}
+
 struct Utils {
     func activateNudge() {
         var msg = "Re-activating Nudge"
@@ -500,6 +506,63 @@ struct Utils {
             NSWorkspace.shared.open(URL(fileURLWithPath: "/System/Library/PreferencePanes/SoftwareUpdate.prefPane"))
             // NSWorkspace.shared.open(URL(fileURLWithPath: "x-apple.systempreferences:com.apple.preferences.softwareupdate?client=softwareupdateapp"))
         }
+    }
+    
+    func isValidColourHex(_ hexvalue: String) -> Bool {
+        let hexRegEx = "^#([a-fA-F0-9]{6})$"
+        let hexPred = NSPredicate(format:"SELF MATCHES %@", hexRegEx)
+        return hexPred.evaluate(with: hexvalue)
+    }
+
+    func stringToColour(_ colourValue: String) -> Color {
+        
+        var returnColor: Color
+        
+        //let colourHash = String(item[1])
+        if isValidColourHex(colourValue) {
+            
+            // valid hex = #000000 format
+        
+            let colourRedValue = "\(colourValue[1])\(colourValue[2])"
+            let colourRed = Double(Int(colourRedValue, radix: 16)!)/255
+            
+            let colourGreenValue = "\(colourValue[3])\(colourValue[4])"
+            let colourGreen = Double(Int(colourGreenValue, radix: 16)!)/255
+            
+            let colourBlueValue = "\(colourValue[5])\(colourValue[6])"
+            let colourBlue = Double(Int(colourBlueValue, radix: 16)!)/255
+            
+            returnColor = Color(red: colourRed, green: colourGreen, blue: colourBlue)
+            
+        } else {
+            switch colourValue {
+                case "black":
+                    returnColor = Color.black
+                case "blue":
+                    returnColor = Color.blue
+                case "gray":
+                    returnColor = Color.gray
+                case "green":
+                    returnColor = Color.green
+                case "orange":
+                    returnColor = Color.orange
+                case "pink":
+                    returnColor = Color.pink
+                case "purple":
+                    returnColor = Color.purple
+                case "red":
+                    returnColor = Color.red
+                case "white":
+                    returnColor = Color.white
+                case "yellow":
+                    returnColor = Color.yellow
+                default:
+                    returnColor = Color.primary
+            }
+        }
+        
+        return returnColor
+        
     }
 
     func userInitiatedExit() {


### PR DESCRIPTION
Added `importantTextColor` as an option in the user Interface settings to modify the interface as suggested in issue https://github.com/macadmins/nudge/issues/307. This currently only changes the "Important Notes" but could be used for other elements that may warrant customisable colour.

colour can be specified as one of the standard SwiftUI pre-baked colours, black, blue, gray, green, orange, pink, purple, red, white, yellow or expressed as hex, e.g. `#ed1091`, default colour is red although because the code is generalised (for other uses perhaps) the default colour if an invalid colour is specified is the system primary colour (black if light mode, white if dark mode).

added `StringProtocol` extension to handle accessing string elements by index
added `stringToColour` and `isValidColourHex` functions in Utils to convert words to Color()

updated example plist and json

example `"importantTextColor": "purple"`  ![image](https://user-images.githubusercontent.com/3598965/154416805-4102d972-321c-4c2e-a565-eff66a957585.png)