### PR TITLE
Add bottom padding to right side main header

### DIFF
--- a/Nudge/UI/StandardMode/RightSide.swift
+++ b/Nudge/UI/StandardMode/RightSide.swift
@@ -57,6 +57,7 @@ struct StandardModeRightSide: View {
             }
             .padding(.leading, contentWidthPadding)
             .padding(.trailing, contentWidthPadding)
+            .padding(.bottom, bottomPadding)
             
             // I'm kind of impressed with myself
             VStack {


### PR DESCRIPTION
Fixes the spacing between the main header and content such that the main header is not directly against the start of the content area and the spacing between them and the background is consistent.

![image](https://user-images.githubusercontent.com/3598965/155524398-29f2dd99-5999-493f-b231-0d5361e184ab.png)
