### PR TITLE
Merge Development blur into development

### DIFF
--- a/Example Assets/com.github.macadmins.Nudge.json
+++ b/Example Assets/com.github.macadmins.Nudge.json
@@ -1,9 +1,11 @@
 {
   "optionalFeatures": {
+    "acceptableCameraUsage": false,
     "acceptableApplicationBundleIDs": [
       "us.zoom.xos"
     ],
     "aggressiveUserExperience": true,
+    "aggressiveUserFullScreenExperience": true,
     "asynchronousSoftwareUpdate": true,
     "attemptToFetchMajorUpgrade": true,
     "enforceMinorUpdates": true

--- a/Example Assets/com.github.macadmins.Nudge.mobileconfig
+++ b/Example Assets/com.github.macadmins.Nudge.mobileconfig
@@ -21,11 +21,15 @@
         <integer>1</integer>
         <key>optionalFeatures</key>
         <dict>
+          <key>acceptableCameraUsage</key>
+          <false/>
           <key>acceptableApplicationBundleIDs</key>
           <array>
             <string>us.zoom.xos</string>
           </array>
           <key>aggressiveUserExperience</key>
+          <true/>
+          <key>aggressiveUserFullScreenExperience</key>
           <true/>
           <key>asynchronousSoftwareUpdate</key>
           <true/>

--- a/Nudge.xcodeproj/project.pbxproj
+++ b/Nudge.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		5836861425DACFE90004514C /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5836861325DACFE90004514C /* Logger.swift */; };
 		5836861C25DAD01C0004514C /* SoftwareUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5836861B25DAD01C0004514C /* SoftwareUpdate.swift */; };
 		5870FF6225CFE5EC0036D203 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5870FF6425CFE5EC0036D203 /* Localizable.strings */; };
+		6316F0E72832CA0700E1354D /* Schema in Resources */ = {isa = PBXBuildFile; fileRef = 6316F0E62832CA0700E1354D /* Schema */; };
 		636B9C0226CACCAB0007BE3B /* DeferView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636B9C0126CACCAB0007BE3B /* DeferView.swift */; };
 		636C4B4A25D1BECE0004A791 /* DefaultPreferencesNudge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636C4B4925D1BECE0004A791 /* DefaultPreferencesNudge.swift */; };
 		636C4B7625D4306A0004A791 /* UILogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636C4B7525D4306A0004A791 /* UILogic.swift */; };
@@ -62,8 +63,8 @@
 		068D23D025DC27EA00FE05A5 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		0B0CCED925CE1C7C00A93D43 /* OSVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSVersion.swift; sourceTree = "<group>"; };
 		0BC9972B25CE2DFC0019FC8F /* OSVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSVersionTests.swift; sourceTree = "<group>"; };
-		414550A727C65A4100D756E3 /* BackgroundBlur.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundBlur.swift; sourceTree = "<group>"; };
 		29AF939527BF8BBF009CD38D /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/Localizable.strings; sourceTree = "<group>"; };
+		414550A727C65A4100D756E3 /* BackgroundBlur.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundBlur.swift; sourceTree = "<group>"; };
 		41AD2AFF26DE65B1004C52B1 /* QuitButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuitButtons.swift; sourceTree = "<group>"; };
 		41AD2B0126DE6947004C52B1 /* AdditionalInfoButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdditionalInfoButton.swift; sourceTree = "<group>"; };
 		41AD2B0326DE6A6B004C52B1 /* CompanyLogo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanyLogo.swift; sourceTree = "<group>"; };
@@ -73,6 +74,7 @@
 		5870FF6325CFE5EC0036D203 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		5870FF6825CFE5FA0036D203 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		630316C127C53143004E1F72 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
+		6316F0E62832CA0700E1354D /* Schema */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Schema; sourceTree = "<group>"; };
 		634075C927206ED70066DFDD /* hi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hi; path = hi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6362D3F72824368E00A4849E /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Localizable.strings; sourceTree = "<group>"; };
 		636B9C0126CACCAB0007BE3B /* DeferView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeferView.swift; sourceTree = "<group>"; };
@@ -148,8 +150,8 @@
 		41AD2AFE26DE657D004C52B1 /* Common */ = {
 			isa = PBXGroup;
 			children = (
-				414550A727C65A4100D756E3 /* BackgroundBlur.swift */,
 				41AD2B0126DE6947004C52B1 /* AdditionalInfoButton.swift */,
+				414550A727C65A4100D756E3 /* BackgroundBlur.swift */,
 				41AD2B0326DE6A6B004C52B1 /* CompanyLogo.swift */,
 				636B9C0126CACCAB0007BE3B /* DeferView.swift */,
 				639B6B5725DF377B00E38EC1 /* DeviceInfo.swift */,
@@ -216,6 +218,7 @@
 			isa = PBXGroup;
 			children = (
 				031B0F2125D8AE3200E68A28 /* Example Assets */,
+				6316F0E62832CA0700E1354D /* Schema */,
 				5870FF6425CFE5EC0036D203 /* Localizable.strings */,
 				63D7D0E125C9E9A400236281 /* Nudge */,
 				63D7D0F425C9E9A500236281 /* NudgeTests */,
@@ -398,6 +401,7 @@
 				63D7D0E725C9E9A500236281 /* Assets.xcassets in Resources */,
 				639B6B0F25DC9ED300E38EC1 /* com.github.macadmins.Nudge.mobileconfig in Resources */,
 				035C2AEC25D8ABC400429458 /* com.github.macadmins.Nudge.json in Resources */,
+				6316F0E72832CA0700E1354D /* Schema in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Nudge/Preferences/DefaultPreferencesNudge.swift
+++ b/Nudge/Preferences/DefaultPreferencesNudge.swift
@@ -31,9 +31,10 @@ let actionButtonPath = osVersionRequirementsProfile?.actionButtonPath ?? osVersi
 // optionalFeatures
 let optionalFeaturesProfile = getOptionalFeaturesProfile()
 let optionalFeaturesJSON = getOptionalFeaturesJSON()
-let aggressiveUserExperience = optionalFeaturesProfile?["aggressiveUserExperience"] as? Bool ?? optionalFeaturesJSON?.aggressiveUserExperience ?? true
 let customAcceptableApplicationBundleIDs = optionalFeaturesProfile?["acceptableApplicationBundleIDs"] as? [String] ?? optionalFeaturesJSON?.acceptableApplicationBundleIDs ?? [""]
 let acceptableCameraUsage = optionalFeaturesProfile?["acceptableCameraUsage"] as? Bool ?? optionalFeaturesJSON?.acceptableCameraUsage ?? false
+let aggressiveUserExperience = optionalFeaturesProfile?["aggressiveUserExperience"] as? Bool ?? optionalFeaturesJSON?.aggressiveUserExperience ?? true
+let aggressiveUserFullScreenExperience = optionalFeaturesProfile?["aggressiveUserFullScreenExperience"] as? Bool ?? optionalFeaturesJSON?.aggressiveUserFullScreenExperience ?? true
 let asynchronousSoftwareUpdate = optionalFeaturesProfile?["asynchronousSoftwareUpdate"] as? Bool ?? optionalFeaturesJSON?.asynchronousSoftwareUpdate ?? true
 let attemptToFetchMajorUpgrade = optionalFeaturesProfile?["attemptToFetchMajorUpgrade"] as? Bool ?? optionalFeaturesJSON?.attemptToFetchMajorUpgrade ?? true
 let enforceMinorUpdates = optionalFeaturesProfile?["enforceMinorUpdates"] as? Bool ?? optionalFeaturesJSON?.enforceMinorUpdates ?? true

--- a/Nudge/Preferences/PreferencesStructure.swift
+++ b/Nudge/Preferences/PreferencesStructure.swift
@@ -61,6 +61,7 @@ struct OptionalFeatures: Codable {
     var acceptableApplicationBundleIDs: [String]?
     var acceptableCameraUsage,
         aggressiveUserExperience,
+        aggressiveUserFullScreenExperience,
         asynchronousSoftwareUpdate,
         attemptToFetchMajorUpgrade,
         disableSoftwareUpdateWorkflow,
@@ -89,6 +90,7 @@ extension OptionalFeatures {
         acceptableApplicationBundleIDs: [String]?? = nil,
         acceptableCameraUsage: Bool?? = nil,
         aggressiveUserExperience: Bool?? = nil,
+        aggressiveUserFullScreenExperience: Bool?? = nil,
         asynchronousSoftwareUpdate: Bool?? = nil,
         attemptToFetchMajorUpgrade: Bool?? = nil,
         disableSoftwareUpdateWorkflow: Bool?? = nil,
@@ -98,6 +100,7 @@ extension OptionalFeatures {
             acceptableApplicationBundleIDs: acceptableApplicationBundleIDs ?? self.acceptableApplicationBundleIDs,
             acceptableCameraUsage: acceptableCameraUsage ?? self.acceptableCameraUsage,
             aggressiveUserExperience: aggressiveUserExperience ?? self.aggressiveUserExperience,
+            aggressiveUserFullScreenExperience: aggressiveUserFullScreenExperience ?? self.aggressiveUserFullScreenExperience,
             asynchronousSoftwareUpdate: asynchronousSoftwareUpdate ?? self.asynchronousSoftwareUpdate,
             attemptToFetchMajorUpgrade: attemptToFetchMajorUpgrade ?? self.attemptToFetchMajorUpgrade,
             disableSoftwareUpdateWorkflow: disableSoftwareUpdateWorkflow ?? self.disableSoftwareUpdateWorkflow,

--- a/Nudge/UI/Common/BackgroundBlur.swift
+++ b/Nudge/UI/Common/BackgroundBlur.swift
@@ -14,24 +14,19 @@ class BlurWindow: NSWindow {
 }
 
 class BlurWindowController: NSWindowController {
-    
     convenience init() {
-        self.init(windowNibName: "")
+        self.init(windowNibName: "BlurWindow")
     }
         
     override func loadWindow() {
-        window = BlurWindow(contentRect: NSMakeRect(0, 0, 100, 100), styleMask: [], backing: .buffered, defer: true)
+        window = BlurWindow(contentRect: NSMakeRect(0, 0, 0, 0), styleMask: [], backing: .buffered, defer: true)
         self.window?.contentViewController = BlurViewController()
-        self.window?.standardWindowButton(.closeButton)?.isHidden = true //hides the red close button
-        self.window?.standardWindowButton(.miniaturizeButton)?.isHidden = true //hides the yellow miniaturize button
-        self.window?.standardWindowButton(.zoomButton)?.isHidden = true //this removes the green zoom button
         self.window?.setFrame((NSScreen.main?.frame)!, display: true)
-        self.window?.collectionBehavior = NSWindow.CollectionBehavior.canJoinAllSpaces
+        self.window?.collectionBehavior = [.canJoinAllSpaces]
     }
 }
 
 class BlurViewController: NSViewController {
-    
     init() {
          super.init(nibName: nil, bundle: nil)
      }
@@ -52,9 +47,14 @@ class BlurViewController: NSViewController {
         
         let blurView = NSVisualEffectView(frame: view.bounds)
         blurView.blendingMode = .behindWindow
-        blurView.material = .hudWindow
+        blurView.material = .fullScreenUI
         blurView.state = .active
         view.window?.contentView?.addSubview(blurView)
+    }
+
+    override func viewWillDisappear() {
+        super.viewWillDisappear()
+        view.window?.contentView?.removeFromSuperview()
     }
     
 }

--- a/Nudge/UI/Common/QuitButtons.swift
+++ b/Nudge/UI/Common/QuitButtons.swift
@@ -60,6 +60,7 @@ struct QuitButtons: View {
                             }
                             if Utils().allow1HourDeferral() {
                                 Button {
+                                    nudgeEventDate = Date()
                                     nudgeDefaults.set(nudgeEventDate.addingTimeInterval(hourTimeInterval), forKey: "deferRunUntil")
                                     userHasClickedDeferralQuitButton(deferralTime: nudgeEventDate.addingTimeInterval(hourTimeInterval))
                                     updateDeferralUI()
@@ -70,6 +71,7 @@ struct QuitButtons: View {
                             }
                             if Utils().allow24HourDeferral() {
                                 Button {
+                                    nudgeEventDate = Date()
                                     nudgeDefaults.set(nudgeEventDate.addingTimeInterval(dayTimeInterval), forKey: "deferRunUntil")
                                     userHasClickedDeferralQuitButton(deferralTime: nudgeEventDate.addingTimeInterval(dayTimeInterval))
                                     updateDeferralUI()

--- a/Nudge/UI/ContentView.swift
+++ b/Nudge/UI/ContentView.swift
@@ -33,7 +33,7 @@ class ViewState: ObservableObject {
     @Published var userQuitDeferrals = nudgeDefaults.object(forKey: "userQuitDeferrals") as? Int ?? 0
     @Published var userRequiredMinimumOSVersion = nudgeDefaults.object(forKey: "requiredMinimumOSVersion") as? String ?? "0.0"
     @Published var userSessionDeferrals = nudgeDefaults.object(forKey: "userSessionDeferrals") as? Int ?? 0
-    @Published var bluredBackground =  BlurWindowController()
+    @Published var blurredBackground =  BlurWindowController()
 }
 
 class LogState {
@@ -58,34 +58,12 @@ struct BackgroundView: View {
     }
 }
 
-// class to control the blurred background
-// TODO: paramatise so it can be initialled for all screens, not just main
-class Background: NSWindowController {
-        
-    override func windowDidLoad() {
-        super.windowDidLoad()
-                
-        if let backgroundWindow = self.window {
-            let mainDisplayRect = NSScreen.main?.frame
-            backgroundWindow.contentRect(forFrameRect: mainDisplayRect!)
-            backgroundWindow.setFrame((NSScreen.main?.frame)!, display: true)
-            backgroundWindow.setFrameOrigin((NSScreen.main?.frame.origin)!)
-            backgroundWindow.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.maximumWindow) - 1 ))
-        }
-    }
-
-    func sendBack() {
-        self.window?.orderBack(self)
-    }
-    
-}
-
 struct ContentView: View {
     @ObservedObject var viewObserved: ViewState
     var forceSimpleMode: Bool = false
     // Setup the main refresh timer that controls the child refresh logic
     let nudgeRefreshCycleTimer = Timer.publish(every: Double(nudgeRefreshCycle), on: .main, in: .common).autoconnect()
-    
+
     var body: some View {
         BackgroundView(forceSimpleMode: forceSimpleMode, viewObserved: viewObserved).background(
             HostingWindowFinder { window in
@@ -94,11 +72,6 @@ struct ContentView: View {
                 window?.standardWindowButton(.zoomButton)?.isHidden = true //this removes the green zoom button
                 window?.center() // center
                 window?.isMovable = false // not movable
-                // load the blur background and send it to the back if we are past the required install date
-                if Utils().pastRequiredInstallationDate() {
-                    viewObserved.bluredBackground.showWindow(self)
-                    NSApp.windows[0].level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.maximumWindow)))
-                }
                 window?.collectionBehavior = [.canJoinAllSpaces]
                 window?.delegate = windowDelegate
                 _ = needToActivateNudge()

--- a/Nudge/UI/StandardMode/RightSide.swift
+++ b/Nudge/UI/StandardMode/RightSide.swift
@@ -84,7 +84,6 @@ struct StandardModeRightSide: View {
                         // actionButton
                         Button(action: {
                             Utils().updateDevice()
-                            viewObserved.bluredBackground.close()
                         }) {
                             Text(actionButtonText)
                         }

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -60,6 +60,13 @@ struct Utils {
         // Sheets do not count as windows though.
         NSApp.activate(ignoringOtherApps: true)
         NSApp.windows[0].makeKeyAndOrderFront(self)
+        
+        // load the blur background and send it to the back if we are past the required install date
+        // if pastRequiredInstallationDate() && aggressiveUserFullScreenExperience {
+        if aggressiveUserFullScreenExperience {
+            nudgePrimaryState.blurredBackground.showWindow(self)
+            NSApp.windows[0].level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.maximumWindow) + 1))
+        }
     }
 
     func allow1HourDeferral() -> Bool {
@@ -516,10 +523,10 @@ struct Utils {
     }
 
     func pastRequiredInstallationDate() -> Bool {
+        var pastRequiredInstallationDate = getCurrentDate() > requiredInstallationDate
         if demoModeEnabled() {
-            return false
+            pastRequiredInstallationDate = false
         }
-        let pastRequiredInstallationDate = getCurrentDate() > requiredInstallationDate
         if !nudgePrimaryState.hasLoggedPastRequiredInstallationDate {
             nudgePrimaryState.hasLoggedPastRequiredInstallationDate = true
             utilsLog.notice("Device pastRequiredInstallationDate: \(pastRequiredInstallationDate, privacy: .public)")
@@ -591,6 +598,10 @@ struct Utils {
             NSWorkspace.shared.open(URL(fileURLWithPath: "/System/Library/PreferencePanes/SoftwareUpdate.prefPane"))
             // NSWorkspace.shared.open(URL(fileURLWithPath: "x-apple.systempreferences:com.apple.preferences.softwareupdate?client=softwareupdateapp"))
         }
+        
+        // turn off blur and allow windows to come above Nudge
+        nudgePrimaryState.blurredBackground.close()
+        NSApp.windows[0].level = .normal
     }
 
     func userInitiatedExit() {

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -64,6 +64,7 @@ struct Utils {
         // load the blur background and send it to the back if we are past the required install date
         // if pastRequiredInstallationDate() && aggressiveUserFullScreenExperience {
         if aggressiveUserFullScreenExperience {
+            nudgePrimaryState.blurredBackground.loadWindow()
             nudgePrimaryState.blurredBackground.showWindow(self)
             NSApp.windows[0].level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.maximumWindow) + 1))
         }

--- a/Schema/jamf/com.github.macadmins.Nudge.json
+++ b/Schema/jamf/com.github.macadmins.Nudge.json
@@ -36,8 +36,36 @@
                 }
               ]
             },
+            "acceptableCameraUsage": {
+              "description": "When enabled, Nudge will not activate or re-activate when the camera is on.",
+              "anyOf": [
+                {
+                  "title": "Not Configured",
+                  "type": "null"
+                },
+                {
+                  "title": "Configured",
+                  "default": false,
+                  "type": "boolean"
+                }
+              ]
+            },
             "aggressiveUserExperience": {
               "description": "When disabled, Nudge will not hide all non-acceptableApplicationBundleIDs after the requiredInstallationDate or allowedDeferrals.",
+              "anyOf": [
+                {
+                  "title": "Not Configured",
+                  "type": "null"
+                },
+                {
+                  "title": "Configured",
+                  "default": true,
+                  "type": "boolean"
+                }
+              ]
+            },
+            "aggressiveUserFullScreenExperience": {
+              "description": "When disabled, Nudge will not create a blurred background when the user is past the deferral window.",
               "anyOf": [
                 {
                   "title": "Not Configured",


### PR DESCRIPTION
Finish out the blurred background v1 code and fix some bugs
- When removing the blur via the update device button, Nudge would stay above all of the windows. If System Preferences was behind Nudge, the user couldn't update.
- Remove unused code that was left from tests
- Moved the blur creation logic to the activation function, allowing the blur to appear for all nudge activation events, not just the first launch.
- Fixed blur logic deactivation in simple mode
- Fixed typos of "blured" to "blurred"
- Remove non-needed code from loadWindow() function of blur and made the other code similar to the style of other window logic
- Moved to fullscreen material for blur
- Ensured the view was removed from the superview when blur is dismissed
- Added new aggressiveFullScreenExperience preference
- Added to json/mdm example and jamf schema
- Added other new keys to jamf schema from previous commits
- Rearranged the project and added schema to xcode info
- Log some more during debug mode
- Ensure blur is always loaded on re-activations
- Attempt to fix https://github.com/macadmins/nudge/issues/338