### PR TITLE
Resolution for issue #377 - "default" targetedOSVersionsRule is Ignored/Overwritten when there's multiple osVersionRequirements

### DIFF
--- a/Nudge/Utilities/Preferences.swift
+++ b/Nudge/Utilities/Preferences.swift
@@ -55,6 +55,7 @@ func getOSVersionRequirementsProfile() -> OSVersionRequirement? {
     var fullMatch = OSVersionRequirement()
     var partialMatch = OSVersionRequirement()
     var defaultMatch = OSVersionRequirement()
+    var defaultMatchSet = false
     if Utils().demoModeEnabled() || Utils().unitTestingEnabled() {
         return nil
     }
@@ -73,7 +74,8 @@ func getOSVersionRequirementsProfile() -> OSVersionRequirement? {
                 partialMatch = subPreferences
             } else if subPreferences.targetedOSVersionsRule == "default" {
                 defaultMatch = subPreferences
-            } else {
+                defaultMatchSet = true
+            } else if !(defaultMatchSet) {
                 defaultMatch = subPreferences
             }
         }
@@ -94,6 +96,7 @@ func getOSVersionRequirementsJSON() -> OSVersionRequirement? {
     var fullMatch = OSVersionRequirement()
     var partialMatch = OSVersionRequirement()
     var defaultMatch = OSVersionRequirement()
+    var defaultMatchSet = false
     if Utils().demoModeEnabled() || Utils().unitTestingEnabled() {
         return nil
     }
@@ -106,7 +109,8 @@ func getOSVersionRequirementsJSON() -> OSVersionRequirement? {
                 partialMatch = subPreferences
             } else if subPreferences.targetedOSVersionsRule == "default" {
                 defaultMatch = subPreferences
-            } else if subPreferences.targetedOSVersionsRule == nil {
+                defaultMatchSet = true
+            } else if subPreferences.targetedOSVersionsRule == nil && !(defaultMatchSet) {
                 defaultMatch = subPreferences
             }
         }


### PR DESCRIPTION
I added a new boolean variable defaultMatchSet to track if the targetedOSVersionsRule has matched against default. Variable set to false on instantiation and set to `true` if a default has been found.

In getOSVersionRequirementsJSON I appended additional conditional statement to `else if subPreferences.targetedOSVersionsRule == nil` preventing the value from being overwritten by subsequent loops.

In getOSVersionRequirementsProfile I have changed the final `else` statement to `else if !(defaultMatchSet)` to prevent overwriting of the default value.