### PR TITLE
add backup path for macOS Ventura installer

### DIFF
--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -308,6 +308,8 @@ struct Utils {
     func getBackupMajorUpgradeAppPath() -> String {
         if getMajorRequiredNudgeOSVersion() == 12 {
             return "/Applications/Install macOS Monterey.app"
+        } else if getMajorRequiredNudgeOSVersion() == 13 {
+            return "/Applications/Install macOS Ventura.app"
         } else { // TODO: Update this for next year with another else if
             return "/Applications/Install macOS Monterey.app"
         }


### PR DESCRIPTION
I ended up reading through the codebase whilst trying to help someone and came across this code which had a todo note