### PR TITLE
Google translate translation fixed

### DIFF
--- a/da.lproj/Localizable.strings
+++ b/da.lproj/Localizable.strings
@@ -21,9 +21,9 @@
 
 //// Left side of Nudge
 // Current OS Version
-"Current OS Version:" = "Nuværende OS-version:";
+"Current OS Version:" = "Nuværende MacOS-version:";
 // Required OS Version
-"Required OS Version:" = "Påkrævet OS-version:";
+"Required OS Version:" = "Påkrævet MacOS-version:";
 // Days Remaining To Update
 "Days Remaining To Update:" = "Tilbageværende dage til at opdatere:";
 // Hours Remaining To Update

--- a/da.lproj/Localizable.strings
+++ b/da.lproj/Localizable.strings
@@ -25,9 +25,9 @@
 // Required OS Version
 "Required OS Version:" = "Påkrævet OS-version:";
 // Days Remaining To Update
-"Days Remaining To Update:" = "Dage at opdatere i:";
+"Days Remaining To Update:" = "Tilbageværende dage til at opdatere:";
 // Hours Remaining To Update
-"Hours Remaining To Update:" = "Timer at opdatere i:";
+"Hours Remaining To Update:" = "Tilbageværende timer til at opdatere:";
 // Deferred Count
 "Deferred Count:" = "Antal udsættelser:";
 // More Info


### PR DESCRIPTION
PR to improve the Danish translation for "Days Remaining".
Also specifying MacOS to avoid confusing non-technical users - they know what MacOS is, they have no idea what OS is. 