### PR TITLE
Hide Nudge instead of Quitting when Deferred

### DIFF
--- a/Example Assets/com.github.macadmins.Nudge.json
+++ b/Example Assets/com.github.macadmins.Nudge.json
@@ -11,8 +11,8 @@
     "attemptToFetchMajorUpgrade": true,
     "blockedApplicationBundleIDs": [],
     "enforceMinorUpdates": true,
-    "terminateApplicationsOnLaunch": false,
-    "hideInsteadofQuit": false
+    "hideInsteadOfQuit": false,
+    "terminateApplicationsOnLaunch": false
   },
   "osVersionRequirements": [
     {

--- a/Example Assets/com.github.macadmins.Nudge.json
+++ b/Example Assets/com.github.macadmins.Nudge.json
@@ -11,7 +11,8 @@
     "attemptToFetchMajorUpgrade": true,
     "blockedApplicationBundleIDs": [],
     "enforceMinorUpdates": true,
-    "terminateApplicationsOnLaunch": false
+    "terminateApplicationsOnLaunch": false,
+    "hideInsteadofQuit": false
   },
   "osVersionRequirements": [
     {

--- a/Example Assets/com.github.macadmins.Nudge.mobileconfig
+++ b/Example Assets/com.github.macadmins.Nudge.mobileconfig
@@ -47,6 +47,8 @@
           <true/>
           <key>terminateApplicationsOnLaunch</key>
           <false/>
+          <key>hideInsteadofQuit</key>
+          <false/>
         </dict>
         <key>osVersionRequirements</key>
         <array>

--- a/Example Assets/com.github.macadmins.Nudge.mobileconfig
+++ b/Example Assets/com.github.macadmins.Nudge.mobileconfig
@@ -45,9 +45,9 @@
           <array/>
           <key>enforceMinorUpdates</key>
           <true/>
+          <key>hideInsteadOfQuit</key>
+          <false/>          
           <key>terminateApplicationsOnLaunch</key>
-          <false/>
-          <key>hideInsteadofQuit</key>
           <false/>
         </dict>
         <key>osVersionRequirements</key>

--- a/Example Assets/com.github.macadmins.Nudge.tester.json
+++ b/Example Assets/com.github.macadmins.Nudge.tester.json
@@ -14,7 +14,8 @@
       "com.microsoft.VSCode",
       "us.zoom.xos"
     ],
-    "terminateApplicationsOnLaunch": false
+    "terminateApplicationsOnLaunch": false,
+    "hideInsteadofQuit": false
   },
   "osVersionRequirements": [
     {

--- a/Example Assets/com.github.macadmins.Nudge.tester.json
+++ b/Example Assets/com.github.macadmins.Nudge.tester.json
@@ -15,7 +15,7 @@
       "us.zoom.xos"
     ],
     "terminateApplicationsOnLaunch": false,
-    "hideInsteadofQuit": false
+    "hideInsteadOfQuit": false
   },
   "osVersionRequirements": [
     {

--- a/Nudge/Preferences/DefaultPreferencesNudge.swift
+++ b/Nudge/Preferences/DefaultPreferencesNudge.swift
@@ -45,6 +45,8 @@ let blockedApplicationBundleIDs = optionalFeaturesProfile?["blockedApplicationBu
 let enforceMinorUpdates = optionalFeaturesProfile?["enforceMinorUpdates"] as? Bool ?? optionalFeaturesJSON?.enforceMinorUpdates ?? true
 let disableSoftwareUpdateWorkflow = optionalFeaturesProfile?["disableSoftwareUpdateWorkflow"] as? Bool ?? optionalFeaturesJSON?.disableSoftwareUpdateWorkflow ?? false
 let terminateApplicationsOnLaunch = optionalFeaturesProfile?["terminateApplicationsOnLaunch"] as? Bool ?? optionalFeaturesJSON?.terminateApplicationsOnLaunch ?? false
+let hideInsteadofQuit = optionalFeaturesProfile?["hideInsteadofQuit"] as? Bool ?? optionalFeaturesJSON?.hideInsteadofQuit ?? false
+
 
 // osVersionRequirements
 let osVersionRequirementsProfile = getOSVersionRequirementsProfile()

--- a/Nudge/Preferences/DefaultPreferencesNudge.swift
+++ b/Nudge/Preferences/DefaultPreferencesNudge.swift
@@ -44,8 +44,8 @@ let attemptToFetchMajorUpgrade = optionalFeaturesProfile?["attemptToFetchMajorUp
 let blockedApplicationBundleIDs = optionalFeaturesProfile?["blockedApplicationBundleIDs"] as? [String] ?? optionalFeaturesJSON?.blockedApplicationBundleIDs ?? [String]()
 let enforceMinorUpdates = optionalFeaturesProfile?["enforceMinorUpdates"] as? Bool ?? optionalFeaturesJSON?.enforceMinorUpdates ?? true
 let disableSoftwareUpdateWorkflow = optionalFeaturesProfile?["disableSoftwareUpdateWorkflow"] as? Bool ?? optionalFeaturesJSON?.disableSoftwareUpdateWorkflow ?? false
+let hideInsteadOfQuit = optionalFeaturesProfile?["hideInsteadOfQuit"] as? Bool ?? optionalFeaturesJSON?.hideInsteadOfQuit ?? false
 let terminateApplicationsOnLaunch = optionalFeaturesProfile?["terminateApplicationsOnLaunch"] as? Bool ?? optionalFeaturesJSON?.terminateApplicationsOnLaunch ?? false
-let hideInsteadofQuit = optionalFeaturesProfile?["hideInsteadofQuit"] as? Bool ?? optionalFeaturesJSON?.hideInsteadofQuit ?? false
 
 
 // osVersionRequirements

--- a/Nudge/Preferences/PreferencesStructure.swift
+++ b/Nudge/Preferences/PreferencesStructure.swift
@@ -70,7 +70,8 @@ struct OptionalFeatures: Codable {
     var blockedApplicationBundleIDs: [String]?
     var disableSoftwareUpdateWorkflow,
         enforceMinorUpdates,
-        terminateApplicationsOnLaunch: Bool?
+        terminateApplicationsOnLaunch: Bool?,
+        hideInsteadofQuit: Bool?
 }
 
 // MARK: OptionalFeatures convenience initializers and mutators
@@ -105,7 +106,8 @@ extension OptionalFeatures {
         blockedApplicationBundleIDs: [String]?? = nil,
         disableSoftwareUpdateWorkflow: Bool?? = nil,
         enforceMinorUpdates: Bool?? = nil,
-        terminateApplicationsOnLaunch: Bool?? = nil
+        terminateApplicationsOnLaunch: Bool?? = nil,
+        hideInsteadofQuit: Bool?? = nil
     ) -> OptionalFeatures {
         return OptionalFeatures(
             acceptableApplicationBundleIDs: acceptableApplicationBundleIDs ?? self.acceptableApplicationBundleIDs,
@@ -121,7 +123,8 @@ extension OptionalFeatures {
             blockedApplicationBundleIDs: blockedApplicationBundleIDs ?? self.blockedApplicationBundleIDs,
             disableSoftwareUpdateWorkflow: disableSoftwareUpdateWorkflow ?? self.disableSoftwareUpdateWorkflow,
             enforceMinorUpdates: enforceMinorUpdates ?? self.enforceMinorUpdates,
-            terminateApplicationsOnLaunch: terminateApplicationsOnLaunch ?? self.terminateApplicationsOnLaunch
+            terminateApplicationsOnLaunch: terminateApplicationsOnLaunch ?? self.terminateApplicationsOnLaunch,
+            hideInsteadofQuit: hideInsteadofQuit ?? self.hideInsteadofQuit
         )
     }
 

--- a/Nudge/Preferences/PreferencesStructure.swift
+++ b/Nudge/Preferences/PreferencesStructure.swift
@@ -124,7 +124,7 @@ extension OptionalFeatures {
             disableSoftwareUpdateWorkflow: disableSoftwareUpdateWorkflow ?? self.disableSoftwareUpdateWorkflow,
             enforceMinorUpdates: enforceMinorUpdates ?? self.enforceMinorUpdates,
             hideInsteadOfQuit: hideInsteadOfQuit ?? self.hideInsteadOfQuit,
-            terminateApplicationsOnLaunch: terminateApplicationsOnLaunch ?? self.terminateApplicationsOnLaunch,
+            terminateApplicationsOnLaunch: terminateApplicationsOnLaunch ?? self.terminateApplicationsOnLaunch
         )
     }
 

--- a/Nudge/Preferences/PreferencesStructure.swift
+++ b/Nudge/Preferences/PreferencesStructure.swift
@@ -70,8 +70,8 @@ struct OptionalFeatures: Codable {
     var blockedApplicationBundleIDs: [String]?
     var disableSoftwareUpdateWorkflow,
         enforceMinorUpdates,
-        terminateApplicationsOnLaunch: Bool?,
-        hideInsteadofQuit: Bool?
+        hideInsteadOfQuit: Bool?,
+        terminateApplicationsOnLaunch: Bool?
 }
 
 // MARK: OptionalFeatures convenience initializers and mutators
@@ -106,8 +106,8 @@ extension OptionalFeatures {
         blockedApplicationBundleIDs: [String]?? = nil,
         disableSoftwareUpdateWorkflow: Bool?? = nil,
         enforceMinorUpdates: Bool?? = nil,
-        terminateApplicationsOnLaunch: Bool?? = nil,
-        hideInsteadofQuit: Bool?? = nil
+        hideInsteadOfQuit: Bool?? = nil,
+        terminateApplicationsOnLaunch: Bool?? = nil
     ) -> OptionalFeatures {
         return OptionalFeatures(
             acceptableApplicationBundleIDs: acceptableApplicationBundleIDs ?? self.acceptableApplicationBundleIDs,
@@ -123,8 +123,8 @@ extension OptionalFeatures {
             blockedApplicationBundleIDs: blockedApplicationBundleIDs ?? self.blockedApplicationBundleIDs,
             disableSoftwareUpdateWorkflow: disableSoftwareUpdateWorkflow ?? self.disableSoftwareUpdateWorkflow,
             enforceMinorUpdates: enforceMinorUpdates ?? self.enforceMinorUpdates,
+            hideInsteadOfQuit: hideInsteadOfQuit ?? self.hideInsteadOfQuit,
             terminateApplicationsOnLaunch: terminateApplicationsOnLaunch ?? self.terminateApplicationsOnLaunch,
-            hideInsteadofQuit: hideInsteadofQuit ?? self.hideInsteadofQuit
         )
     }
 

--- a/Nudge/UI/Common/DeferView.swift
+++ b/Nudge/UI/Common/DeferView.swift
@@ -67,6 +67,7 @@ struct DeferView: View {
                 Utils().logUserQuitDeferrals()
                 Utils().logUserDeferrals()
                 Utils().userInitiatedExit()
+                self.presentationMode.wrappedValue.dismiss()
             } label: {
                 Text(customDeferralDropdownText)
                     .frame(minWidth: 35)

--- a/Nudge/UI/Main.swift
+++ b/Nudge/UI/Main.swift
@@ -16,6 +16,7 @@ let bundle = Bundle.main
 let serialNumber = Utils().getSerialNumber()
 let configJSON = Utils().getConfigurationAsJSON()
 let configProfile = Utils().getConfigurationAsProfile()
+var hideNudge = false
 
 // Create an AppDelegate so that we can more finely control how Nudge operates
 class AppDelegate: NSObject, NSApplicationDelegate {

--- a/Nudge/Utilities/UILogic.swift
+++ b/Nudge/Utilities/UILogic.swift
@@ -66,6 +66,9 @@ func nudgeStartLogic() {
     let deferralDate = nudgePrimaryState.deferRunUntil ?? nudgePrimaryState.lastRefreshTime
     if (deferralDate > Utils().getCurrentDate()) && !(deferralDate > requiredInstallationDate) && !Utils().pastRequiredInstallationDate() {
         uiLog.notice("\("User has selected a deferral date (\(nudgePrimaryState.deferRunUntil ?? nudgePrimaryState.lastRefreshTime)) that is greater than the launch date (\(Utils().getCurrentDate()))", privacy: .public)")
+        if hideInsteadofQuit {
+                    hideNudge = true
+        }
         Utils().exitNudge()
     }
     if Utils().fullyUpdated() {

--- a/Nudge/Utilities/UILogic.swift
+++ b/Nudge/Utilities/UILogic.swift
@@ -66,8 +66,8 @@ func nudgeStartLogic() {
     let deferralDate = nudgePrimaryState.deferRunUntil ?? nudgePrimaryState.lastRefreshTime
     if (deferralDate > Utils().getCurrentDate()) && !(deferralDate > requiredInstallationDate) && !Utils().pastRequiredInstallationDate() {
         uiLog.notice("\("User has selected a deferral date (\(nudgePrimaryState.deferRunUntil ?? nudgePrimaryState.lastRefreshTime)) that is greater than the launch date (\(Utils().getCurrentDate()))", privacy: .public)")
-        if hideInsteadofQuit {
-                    hideNudge = true
+        if hideInsteadOfQuit {
+            hideNudge = true
         }
         Utils().exitNudge()
     }
@@ -78,11 +78,11 @@ func nudgeStartLogic() {
             return
         } else {
             uiLog.notice("\("Device is fully updated", privacy: .public)")
-            Utils().exitNudge()
+            Utils().exitNudge(shouldReallyHide: false)
         }
     } else if enforceMinorUpdates == false && Utils().requireMajorUpgrade() == false {
         uiLog.warning("\("Device requires a minor update but enforceMinorUpdates is false", privacy: .public)")
-        Utils().exitNudge()
+        Utils().exitNudge(shouldReallyHide: false)
     }
 }
 

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -936,7 +936,11 @@ struct Utils {
     func userInitiatedExit() {
         uiLog.notice("\("User clicked primaryQuitButton", privacy: .public)")
         nudgePrimaryState.shouldExit = true
-        exit(0)
+        if hideInsteadofQuit {
+            NSApp.hide(nil)
+        } else {
+            exit(0)
+        }
     }
 
     func userInitiatedDeviceInfo() {

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -168,8 +168,14 @@ struct Utils {
             uiLog.notice("\("Bypassing activation due to full screen bugs in macOS", privacy: .public)")
             return
         } else {
-            NSApp.activate(ignoringOtherApps: true)
-            NSApp.windows[0].makeKeyAndOrderFront(self)
+            if !hideNudge {
+                NSApp.activate(ignoringOtherApps: true)
+                NSApp.windows[0].makeKeyAndOrderFront(self)
+            } else {
+                NSApp.hide(nil)
+            }
+            hideNudge = false
+            return
         }
     }
 
@@ -279,9 +285,15 @@ struct Utils {
     }
 
     func exitNudge() {
-        uiLog.notice("\("Nudge is terminating due to condition met", privacy: .public)")
-        nudgePrimaryState.shouldExit = true
-        exit(0)
+        if hideInsteadofQuit {
+            uiLog.notice("\("Nudge is hiding due to condition met", privacy: .public)")
+            NSApp.hide(nil)
+            return
+        } else {
+            uiLog.notice("\("Nudge is terminating due to condition met", privacy: .public)")
+            nudgePrimaryState.shouldExit = true
+            exit(0)
+        }
     }
 
     func forceScreenShotIconModeEnabled() -> Bool {

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -284,8 +284,8 @@ struct Utils {
         return unitTestingArgumentPassed
     }
 
-    func exitNudge() {
-        if hideInsteadofQuit {
+    func exitNudge(shouldReallyHide: Bool = true) {
+        if hideInsteadOfQuit && shouldReallyHide {
             uiLog.notice("\("Nudge is hiding due to condition met", privacy: .public)")
             NSApp.hide(nil)
             return
@@ -936,7 +936,7 @@ struct Utils {
     func userInitiatedExit() {
         uiLog.notice("\("User clicked primaryQuitButton", privacy: .public)")
         nudgePrimaryState.shouldExit = true
-        if hideInsteadofQuit {
+        if hideInsteadOfQuit {
             NSApp.hide(nil)
         } else {
             exit(0)

--- a/Schema/jamf/com.github.macadmins.Nudge.json
+++ b/Schema/jamf/com.github.macadmins.Nudge.json
@@ -233,7 +233,19 @@
                   "default": false
                 }
               ]
-            }
+            },
+            "hideInsteadofQuit": {
+              "description": "When enabled, Nudge will hide Nudge instead of quitting when a user clicks 'Later' or any deferral.",
+              "anyOf": [
+                {
+                  "type": "null",
+                  "title": "Not Configured"
+                },
+                {
+                  "title": "Configured",
+                  "type": "boolean",
+                  "default": false
+                }
           }
         }
       ]

--- a/Schema/jamf/com.github.macadmins.Nudge.json
+++ b/Schema/jamf/com.github.macadmins.Nudge.json
@@ -220,6 +220,20 @@
                 }
               ]
             },
+            "hideInsteadOfQuit": {
+              "description": "When enabled, Nudge will hide Nudge instead of quitting when a user clicks 'Later' or any deferral.",
+              "anyOf": [
+                {
+                  "type": "null",
+                  "title": "Not Configured"
+                },
+                {
+                  "title": "Configured",
+                  "type": "boolean",
+                  "default": false
+                }
+              ]
+          },
             "terminateApplicationsOnLaunch": {
               "description": "When enabled, Nudge will terminate the applications listed in blockedApplicationBundleIDs upon initial launch.",
               "anyOf": [
@@ -233,20 +247,7 @@
                   "default": false
                 }
               ]
-            },
-            "hideInsteadofQuit": {
-              "description": "When enabled, Nudge will hide Nudge instead of quitting when a user clicks 'Later' or any deferral.",
-              "anyOf": [
-                {
-                  "type": "null",
-                  "title": "Not Configured"
-                },
-                {
-                  "title": "Configured",
-                  "type": "boolean",
-                  "default": false
-                }
-          }
+            }
         }
       ]
     },


### PR DESCRIPTION
In our Org and speaking with others, it seems confusing that Nudge quits when later is clicked which then the launch agent takes over and the person gets Nudged 30 minutes later when using the default launch agent.

This adds the option hideInsteadOfQuit under optionalFeatures which by default is set to false so anyone wanting to use the current way can easily continue doing it. If set to true, it will then do the new behavior. 

Very little resource is used by Nudge hiding in the background vs quitting, so no real performance issues are caused.