### PR TITLE
Fix bug where softwareupdate could download the wrong update

### DIFF
--- a/Nudge/Utilities/SoftwareUpdate.swift
+++ b/Nudge/Utilities/SoftwareUpdate.swift
@@ -106,7 +106,7 @@ class SoftwareUpdate {
             let softwareupdateList = self.List()
             var updateLabel = ""
             for update in softwareupdateList.components(separatedBy: "\n") {
-                if update.contains("Label:") {
+                if update.contains("Label:") && update.contains(requiredMinimumOSVersion) {
                     updateLabel = update.components(separatedBy: ": ")[1]
                 }
             }


### PR DESCRIPTION
SoftwareUpdate.Download() has a bug in which it could download the wrong update when expecting requireMinimumOSVersion. Currently it iterates over each line returned by List() and, if it contains "Label:", assigns it to updateLabel. However, there's no check that that label is for the os update. If the os update is present in softwareupdateList, but isn't the last label returned, softwareupdate would then download whatever the last update listed is.

A quick check that the label contains the requiredMinimumOSVersion resolves this.