### PR TITLE
Fix: French Localizable.strings

### DIFF
--- a/fr.lproj/Localizable.strings
+++ b/fr.lproj/Localizable.strings
@@ -27,7 +27,7 @@
 // Days Remaining To Update
 "Days Remaining To Update:" = "Jours restants :";
 // Hours Remaining To Update
-"Hours Remaining To Update:" = "Heures restants :";
+"Hours Remaining To Update:" = "Heures restantes :";
 // Deferred Count
 "Deferred Count:" = "Décompte différé :";
 // More Info


### PR DESCRIPTION
In French, "Hour" is a feminine word.