### PR TITLE
SMAppService changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.13] - 2023-10-05
+### Fixed
+- [SMAppService preventing legacy LaunchAgent from loading](https://github.com/macadmins/nudge/pull/516)
+
 ## [1.1.12] - 2023-09-25
 ### Added
 - `calendarDeferralUnit` key to utilize the `approachingWindowTime` or `imminentWindowTime` for calendar deferrals

--- a/Nudge.xcodeproj/project.pbxproj
+++ b/Nudge.xcodeproj/project.pbxproj
@@ -40,8 +40,8 @@
 		63D7D0F625C9E9A500236281 /* NudgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D7D0F525C9E9A500236281 /* NudgeTests.swift */; };
 		63D7D10125C9E9A500236281 /* NudgeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D7D10025C9E9A500236281 /* NudgeUITests.swift */; };
 		63D7D12725C9F1EE00236281 /* StandardMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D7D12625C9F1EE00236281 /* StandardMode.swift */; };
-		73CC1D7829B81EE500FBF8E2 /* com.github.macadmins.Nudge.plist in Resources */ = {isa = PBXBuildFile; fileRef = 73CC1D7729B81EE500FBF8E2 /* com.github.macadmins.Nudge.plist */; };
-		73CC1D7A29B81F0600FBF8E2 /* com.github.macadmins.Nudge.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = 73CC1D7729B81EE500FBF8E2 /* com.github.macadmins.Nudge.plist */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		73CC1D7829B81EE500FBF8E2 /* com.github.macadmins.Nudge.SMAppService.plist in Resources */ = {isa = PBXBuildFile; fileRef = 73CC1D7729B81EE500FBF8E2 /* com.github.macadmins.Nudge.SMAppService.plist */; };
+		73CC1D7A29B81F0600FBF8E2 /* com.github.macadmins.Nudge.SMAppService.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = 73CC1D7729B81EE500FBF8E2 /* com.github.macadmins.Nudge.SMAppService.plist */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -68,7 +68,7 @@
 			dstPath = Nudge.app/Contents/Library/LaunchAgents;
 			dstSubfolderSpec = 16;
 			files = (
-				73CC1D7A29B81F0600FBF8E2 /* com.github.macadmins.Nudge.plist in CopyFiles */,
+				73CC1D7A29B81F0600FBF8E2 /* com.github.macadmins.Nudge.SMAppService.plist in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -116,7 +116,7 @@
 		63D7D10025C9E9A500236281 /* NudgeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NudgeUITests.swift; sourceTree = "<group>"; };
 		63D7D10225C9E9A500236281 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		63D7D12625C9F1EE00236281 /* StandardMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandardMode.swift; sourceTree = "<group>"; };
-		73CC1D7729B81EE500FBF8E2 /* com.github.macadmins.Nudge.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = com.github.macadmins.Nudge.plist; sourceTree = "<group>"; };
+		73CC1D7729B81EE500FBF8E2 /* com.github.macadmins.Nudge.SMAppService.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = com.github.macadmins.Nudge.SMAppService.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -248,7 +248,7 @@
 		63D7D0E125C9E9A400236281 /* Nudge */ = {
 			isa = PBXGroup;
 			children = (
-				73CC1D7729B81EE500FBF8E2 /* com.github.macadmins.Nudge.plist */,
+				73CC1D7729B81EE500FBF8E2 /* com.github.macadmins.Nudge.SMAppService.plist */,
 				639B6B5425DF374600E38EC1 /* UI */,
 				639B6B3925DF1FEB00E38EC1 /* Preferences */,
 				639B6B4725DF218900E38EC1 /* Utilities */,
@@ -412,7 +412,7 @@
 				63D7D0EA25C9E9A500236281 /* Preview Assets.xcassets in Resources */,
 				63D7D0E725C9E9A500236281 /* Assets.xcassets in Resources */,
 				639B6B0F25DC9ED300E38EC1 /* com.github.macadmins.Nudge.mobileconfig in Resources */,
-				73CC1D7829B81EE500FBF8E2 /* com.github.macadmins.Nudge.plist in Resources */,
+				73CC1D7829B81EE500FBF8E2 /* com.github.macadmins.Nudge.SMAppService.plist in Resources */,
 				63C6A08E2833FB6500D5264A /* com.github.macadmins.Nudge.tester.json in Resources */,
 				035C2AEC25D8ABC400429458 /* com.github.macadmins.Nudge.json in Resources */,
 				6316F0E72832CA0700E1354D /* Schema in Resources */,

--- a/Nudge/Info.plist
+++ b/Nudge/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.12</string>
+	<string>1.1.13</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.12</string>
+	<string>1.1.13</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Nudge/UI/Main.swift
+++ b/Nudge/UI/Main.swift
@@ -387,7 +387,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationWillFinishLaunching(_ notification: Notification) {
         // print("applicationWillFinishLaunching")
         if #available(macOS 13, *) {
-            let appService = SMAppService.agent(plistName: "com.github.macadmins.Nudge.plist")
+            let appService = SMAppService.agent(plistName: "com.github.macadmins.Nudge.SMAppService.plist")
             let appServiceStatus = appService.status
             if CommandLine.arguments.contains("--register") || loadLaunchAgent {
                 Utils().loadSMAppLaunchAgent(appService: appService, appServiceStatus: appServiceStatus)

--- a/Nudge/com.github.macadmins.Nudge.SMAppService.plist
+++ b/Nudge/com.github.macadmins.Nudge.SMAppService.plist
@@ -7,7 +7,7 @@
 		<string>com.github.macadmins.Nudge</string>
 	</array>
 	<key>Label</key>
-	<string>com.github.macadmins.Nudge</string>
+	<string>com.github.macadmins.Nudge.SMAppService</string>
 	<key>LimitLoadToSessionType</key>
 	<array>
 		<string>Aqua</string>


### PR DESCRIPTION
Addresses #515

This PR renames the bundled `SMAppService` LaunchAgent and changes the `Label` to be distinct from the legacy LaunchAgent in `/Library/LaunchAgents/` which is widely used.

This may not be a longterm solution around `SMAppService` but does restore previous behavior of the legacy LaunchAgent for now.