### PR TITLE
Add remediation for BTM corruption if users are upgrading from 1.1.12.81501

### DIFF
--- a/build_assets/postinstall-app
+++ b/build_assets/postinstall-app
@@ -22,19 +22,23 @@ if [[ -f /private/var/tmp/nudge_remediate ]]; then
   # Determine BTM plist path. On macOS 13.3 and lower, v4; higher and on to 14, v8.
   if [[ -f "/private/var/db/com.apple.backgroundtaskmanagement/BackgroundItems-v8.btm" ]]; then
     btm_plist_path="/private/var/db/com.apple.backgroundtaskmanagement/BackgroundItems-v8.btm"
+    remediate=True
     echo "Set BTM plist path to v8"
   elif [[ -f "/private/var/db/com.apple.backgroundtaskmanagement/BackgroundItems-v4.btm" ]]; then
     btm_plist_path="/private/var/db/com.apple.backgroundtaskmanagement/BackgroundItems-v4.btm"
+    remediate=True
     echo "Set BTM plist path to v4"
   else
     echo "Error: unable to locate a BTM plist, no remediation occurred. Does this OS support BTM features?"
+    remediate=False
+    break
   fi  
 
   line_count=0
   signing_re='.*"com.github.macadmins.Nudge".*T4SK8ZXCXG\)'
   dne_re=", Does Not Exist"
 
-  while True; do
+  while $remediate; do
     plist_entry=$(/usr/libexec/PlistBuddy -c "Print :\$objects:$line_count" $btm_plist_path 2>&1)
     plist_entry=$(iconv -f ISO-8859-1 <<< $plist_entry)
     if [[ "$plist_entry" =~ $signing_re ]]; then

--- a/build_assets/postinstall-app
+++ b/build_assets/postinstall-app
@@ -1,0 +1,62 @@
+#!/bin/zsh
+#
+# Copyright 2021-Present Erik Gomez.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# In Nudge 1.1.12.81501, a duplicate label caused corruption in the BTM database.
+# Check for the touch file left by preinstall, and if present, remediate the corruption.
+if [[ -f /private/var/tmp/nudge_remediate ]]; then
+  echo "Upgrading from Nudge 1.1.12.81501 - proceeding with remediation."
+
+  # Determine BTM plist path. On macOS 13.3 and lower, v4; higher and on to 14, v8.
+  if [[ -f "/private/var/db/com.apple.backgroundtaskmanagement/BackgroundItems-v8.btm" ]]; then
+    btm_plist_path="/private/var/db/com.apple.backgroundtaskmanagement/BackgroundItems-v8.btm"
+    echo "Set BTM plist path to v8"
+  elif [[ -f "/private/var/db/com.apple.backgroundtaskmanagement/BackgroundItems-v4.btm" ]]; then
+    btm_plist_path="/private/var/db/com.apple.backgroundtaskmanagement/BackgroundItems-v4.btm"
+    echo "Set BTM plist path to v4"
+  else
+    echo "Error: unable to locate a BTM plist, no remediation occurred. Does this OS support BTM features?"
+  fi  
+
+  line_count=0
+  signing_re='.*"com.github.macadmins.Nudge".*T4SK8ZXCXG\)'
+  dne_re=", Does Not Exist"
+
+  while True; do
+    plist_entry=$(/usr/libexec/PlistBuddy -c "Print :\$objects:$line_count" $btm_plist_path 2>&1)
+    plist_entry=$(iconv -f ISO-8859-1 <<< $plist_entry)
+    if [[ "$plist_entry" =~ $signing_re ]]; then
+      # Remove the bad entry
+      /usr/libexec/PlistBuddy -c "Delete :\$objects:$line_count" $btm_plist_path
+      # Kickstart BTM to load in the modified DB
+      /bin/launchctl kickstart -k system/com.apple.backgroundtaskmanagementd
+      echo "Remediated BTM DB and kickstarted service."
+      break
+
+    elif [[ "$plist_entry" =~ ", Does Not Exist" ]] || [[ $line_count -gt 100000 ]]; then
+      # Exit if we hit the end of the file or 100,000 lines (to avoid runaway)
+      echo "Error: did not find signing data entry, or timed out at 100,000 lines processed."
+      break
+    else
+      ((line_count++))
+    fi
+  done
+
+  # Remove the touch file to not trigger remediation again.
+  rm /private/var/tmp/nudge_remediate
+
+else
+  echo "No remediation needed for BTM issues."
+fi

--- a/build_assets/postinstall-launchagent
+++ b/build_assets/postinstall-launchagent
@@ -54,7 +54,7 @@ if [[ -f /private/var/tmp/nudge_remediate ]]; then
     elif [[ ${plist_entry} =~ ", Does Not Exist" ]] || [[ $line_count -gt 100000 ]]; then
       # Exit if we hit the end of the file or 100,000 lines (to avoid runaway)
       echo "Error: did not find signing data entry, or timed out at 100,000 lines processed."
-
+      break
     else
       ((line_count++))
     fi

--- a/build_assets/postinstall-launchagent
+++ b/build_assets/postinstall-launchagent
@@ -21,9 +21,9 @@ launch_agent_plist_name='com.github.macadmins.Nudge.plist'
 launch_agent_base_path='Library/LaunchAgents/'
 
 # In Nudge 1.1.12.81501, a duplicate label caused corruption in the BTM database.
-# Check if we are upgrading from 81501, and if so, remediate the corruption.
-if /usr/bin/grep -q -e ".*1.1.12.81501.*" /Applications/Utilities/Nudge.app/Contents/Info.plist; then
-  echo "Nudge 1.1.12.81501 is installed - proceeding with remediation."
+# Check for the touch file left by preinstall, and if present, remediate the corruption.
+if [[ -f /private/var/tmp/nudge_remediate ]]; then
+  echo "Upgrading from Nudge 1.1.12.81501 - proceeding with remediation."
 
   # Determine BTM plist path. On macOS 13.3 and lower, v4; higher and on to 14, v8.
   if [[ -f "/private/var/db/com.apple.backgroundtaskmanagement/BackgroundItems-v8.btm" ]]; then
@@ -36,25 +36,33 @@ if /usr/bin/grep -q -e ".*1.1.12.81501.*" /Applications/Utilities/Nudge.app/Cont
     echo "Error: unable to locate a BTM plist, no remediation occurred. Does this OS support BTM features?"
   fi
 
-  line_count = 0
+  line_count=0
   signing_re='.*"com.github.macadmins.Nudge".*T4SK8ZXCXG\)'
+  dne_re=", Does Not Exist"
+  signing_string='anchor apple generic and identifier \"com.github.macadmins.Nudge\" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = T4SK8ZXCXG)"'
 
   while True; do
     plist_entry=$(/usr/libexec/PlistBuddy -c "Print :\$objects:$line_count" $btm_plist_path 2>&1)
     if [[ "${plist_entry}" =~ $signing_re ]]; then
       # Remove the bad entry
-      /usr/libexec/PlistBuddy -c "Delete :\$objects:$line_count" $btm_plist
+      /usr/libexec/PlistBuddy -c "Delete :\$objects:$line_count" $btm_plist_path
       # Kickstart BTM to load in the modified DB
       /bin/launchctl kickstart -k system/com.apple.backgroundtaskmanagementd
+      echo "Remediated BTM DB and kickstarted service."
       break
 
     elif [[ ${plist_entry} =~ ", Does Not Exist" ]] || [[ $line_count -gt 100000 ]]; then
-      # Exit if we've ran through the entire plist or we hit 100,000 lines (to avoid runaway)
+      # Exit if we hit the end of the file or 100,000 lines (to avoid runaway)
       echo "Error: did not find signing data entry, or timed out at 100,000 lines processed."
+
     else
-      ((LINE_COUNT++))
+      ((line_count++))
     fi
   done
+
+  # Remove the touch file to not trigger remediation again.
+  rm /private/var/tmp/nudge_remediate
+
 else
   echo "No remediation needed for BTM issues."
 fi

--- a/build_assets/postinstall-launchagent
+++ b/build_assets/postinstall-launchagent
@@ -20,53 +20,6 @@ launch_agent_plist_name='com.github.macadmins.Nudge.plist'
 # Base paths
 launch_agent_base_path='Library/LaunchAgents/'
 
-# In Nudge 1.1.12.81501, a duplicate label caused corruption in the BTM database.
-# Check for the touch file left by preinstall, and if present, remediate the corruption.
-if [[ -f /private/var/tmp/nudge_remediate ]]; then
-  echo "Upgrading from Nudge 1.1.12.81501 - proceeding with remediation."
-
-  # Determine BTM plist path. On macOS 13.3 and lower, v4; higher and on to 14, v8.
-  if [[ -f "/private/var/db/com.apple.backgroundtaskmanagement/BackgroundItems-v8.btm" ]]; then
-    btm_plist_path="/private/var/db/com.apple.backgroundtaskmanagement/BackgroundItems-v8.btm"
-    echo "Set BTM plist path to v8"
-  elif [[ -f "/private/var/db/com.apple.backgroundtaskmanagement/BackgroundItems-v4.btm" ]]; then
-    btm_plist_path="/private/var/db/com.apple.backgroundtaskmanagement/BackgroundItems-v4.btm"
-    echo "Set BTM plist path to v4"
-  else
-    echo "Error: unable to locate a BTM plist, no remediation occurred. Does this OS support BTM features?"
-  fi
-
-  line_count=0
-  signing_re='.*"com.github.macadmins.Nudge".*T4SK8ZXCXG\)'
-  dne_re=", Does Not Exist"
-  signing_string='anchor apple generic and identifier \"com.github.macadmins.Nudge\" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = T4SK8ZXCXG)"'
-
-  while True; do
-    plist_entry=$(/usr/libexec/PlistBuddy -c "Print :\$objects:$line_count" $btm_plist_path 2>&1)
-    if [[ "${plist_entry}" =~ $signing_re ]]; then
-      # Remove the bad entry
-      /usr/libexec/PlistBuddy -c "Delete :\$objects:$line_count" $btm_plist_path
-      # Kickstart BTM to load in the modified DB
-      /bin/launchctl kickstart -k system/com.apple.backgroundtaskmanagementd
-      echo "Remediated BTM DB and kickstarted service."
-      break
-
-    elif [[ ${plist_entry} =~ ", Does Not Exist" ]] || [[ $line_count -gt 100000 ]]; then
-      # Exit if we hit the end of the file or 100,000 lines (to avoid runaway)
-      echo "Error: did not find signing data entry, or timed out at 100,000 lines processed."
-      break
-    else
-      ((line_count++))
-    fi
-  done
-
-  # Remove the touch file to not trigger remediation again.
-  rm /private/var/tmp/nudge_remediate
-
-else
-  echo "No remediation needed for BTM issues."
-fi
-
 # Load agent if installing to a running system
 if [[ $3 == "/" ]] ; then
   # Fail the install if the admin forgets to change their paths and they don't exist.

--- a/build_assets/postinstall-launchagent
+++ b/build_assets/postinstall-launchagent
@@ -20,6 +20,45 @@ launch_agent_plist_name='com.github.macadmins.Nudge.plist'
 # Base paths
 launch_agent_base_path='Library/LaunchAgents/'
 
+# In Nudge 1.1.12.81501, a duplicate label caused corruption in the BTM database.
+# Check if we are upgrading from 81501, and if so, remediate the corruption.
+if /usr/bin/grep -q -e ".*1.1.12.81501.*" /Applications/Utilities/Nudge.app/Contents/Info.plist; then
+  echo "Nudge 1.1.12.81501 is installed - proceeding with remediation."
+
+  # Determine BTM plist path. On macOS 13.3 and lower, v4; higher and on to 14, v8.
+  if [[ -f "/private/var/db/com.apple.backgroundtaskmanagement/BackgroundItems-v8.btm" ]]; then
+    btm_plist_path="/private/var/db/com.apple.backgroundtaskmanagement/BackgroundItems-v8.btm"
+    echo "Set BTM plist path to v8"
+  elif [[ -f "/private/var/db/com.apple.backgroundtaskmanagement/BackgroundItems-v4.btm" ]]; then
+    btm_plist_path="/private/var/db/com.apple.backgroundtaskmanagement/BackgroundItems-v4.btm"
+    echo "Set BTM plist path to v4"
+  else
+    echo "Error: unable to locate a BTM plist, no remediation occurred. Does this OS support BTM features?"
+  fi
+
+  line_count = 0
+  signing_re='.*"com.github.macadmins.Nudge".*T4SK8ZXCXG\)'
+
+  while True; do
+    plist_entry=$(/usr/libexec/PlistBuddy -c "Print :\$objects:$line_count" $btm_plist_path 2>&1)
+    if [[ "${plist_entry}" =~ $signing_re ]]; then
+      # Remove the bad entry
+      /usr/libexec/PlistBuddy -c "Delete :\$objects:$line_count" $btm_plist
+      # Kickstart BTM to load in the modified DB
+      /bin/launchctl kickstart -k system/com.apple.backgroundtaskmanagementd
+      break
+
+    elif [[ ${plist_entry} =~ ", Does Not Exist" ]] || [[ $line_count -gt 100000 ]]; then
+      # Exit if we've ran through the entire plist or we hit 100,000 lines (to avoid runaway)
+      echo "Error: did not find signing data entry, or timed out at 100,000 lines processed."
+    else
+      ((LINE_COUNT++))
+    fi
+  done
+else
+  echo "No remediation needed for BTM issues."
+fi
+
 # Load agent if installing to a running system
 if [[ $3 == "/" ]] ; then
   # Fail the install if the admin forgets to change their paths and they don't exist.

--- a/build_assets/postinstall-suite
+++ b/build_assets/postinstall-suite
@@ -41,7 +41,7 @@ if [[ -f /private/var/tmp/nudge_remediate ]]; then
 
   while True; do
     plist_entry=$(/usr/libexec/PlistBuddy -c "Print :\$objects:$line_count" $btm_plist_path 2>&1)
-    if [[ "${plist_entry}" =~ $signing_re ]]; then
+    if [[ "$plist_entry" =~ $signing_re ]]; then
       # Remove the bad entry
       /usr/libexec/PlistBuddy -c "Delete :\$objects:$line_count" $btm_plist_path
       # Kickstart BTM to load in the modified DB
@@ -49,10 +49,10 @@ if [[ -f /private/var/tmp/nudge_remediate ]]; then
       echo "Remediated BTM DB and kickstarted service."
       break
 
-    elif [[ ${plist_entry} =~ ", Does Not Exist" ]] || [[ $line_count -gt 100000 ]]; then
+    elif [[ "$plist_entry" =~ ", Does Not Exist" ]] || [[ $line_count -gt 100000 ]]; then
       # Exit if we hit the end of the file or 100,000 lines (to avoid runaway)
       echo "Error: did not find signing data entry, or timed out at 100,000 lines processed."
-
+      break
     else
       ((line_count++))
     fi

--- a/build_assets/postinstall-suite
+++ b/build_assets/postinstall-suite
@@ -37,10 +37,10 @@ if [[ -f /private/var/tmp/nudge_remediate ]]; then
   line_count=0
   signing_re='.*"com.github.macadmins.Nudge".*T4SK8ZXCXG\)'
   dne_re=", Does Not Exist"
-  signing_string='anchor apple generic and identifier \"com.github.macadmins.Nudge\" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = T4SK8ZXCXG)"'
 
   while True; do
     plist_entry=$(/usr/libexec/PlistBuddy -c "Print :\$objects:$line_count" $btm_plist_path 2>&1)
+    plist_entry=$(iconv -f ISO-8859-1 <<< $plist_entry)
     if [[ "$plist_entry" =~ $signing_re ]]; then
       # Remove the bad entry
       /usr/libexec/PlistBuddy -c "Delete :\$objects:$line_count" $btm_plist_path

--- a/build_assets/postinstall-suite
+++ b/build_assets/postinstall-suite
@@ -18,6 +18,45 @@
 launch_agent_plist_name='com.github.macadmins.Nudge.plist'
 launch_daemon_plist_name='com.github.macadmins.Nudge.logger.plist'
 
+# In Nudge 1.1.12.81501, a duplicate label caused corruption in the BTM database.
+# Check if we are upgrading from 81501, and if so, remediate the corruption.
+if /usr/bin/grep -q -e ".*1.1.12.81501.*" /Applications/Utilities/Nudge.app/Contents/Info.plist; then
+  echo "Nudge 1.1.12.81501 is installed - proceeding with remediation."
+
+  # Determine BTM plist path. On macOS 13.3 and lower, v4; higher and on to 14, v8.
+  if [[ -f "/private/var/db/com.apple.backgroundtaskmanagement/BackgroundItems-v8.btm" ]]; then
+    btm_plist_path="/private/var/db/com.apple.backgroundtaskmanagement/BackgroundItems-v8.btm"
+    echo "Set BTM plist path to v8"
+  elif [[ -f "/private/var/db/com.apple.backgroundtaskmanagement/BackgroundItems-v4.btm" ]]; then
+    btm_plist_path="/private/var/db/com.apple.backgroundtaskmanagement/BackgroundItems-v4.btm"
+    echo "Set BTM plist path to v4"
+  else
+    echo "Error: unable to locate a BTM plist, no remediation occurred. Does this OS support BTM features?"
+  fi
+
+  line_count = 0
+  signing_re='.*"com.github.macadmins.Nudge".*T4SK8ZXCXG\)'
+
+  while True; do
+    plist_entry=$(/usr/libexec/PlistBuddy -c "Print :\$objects:$line_count" $btm_plist_path 2>&1)
+    if [[ "${plist_entry}" =~ $signing_re ]]; then
+      # Remove the bad entry
+      /usr/libexec/PlistBuddy -c "Delete :\$objects:$line_count" $btm_plist
+      # Kickstart BTM to load in the modified DB
+      /bin/launchctl kickstart -k system/com.apple.backgroundtaskmanagementd
+      break
+
+    elif [[ ${plist_entry} =~ ", Does Not Exist" ]] || [[ $line_count -gt 100000 ]]; then
+      # Exit if we've ran through the entire plist or we hit 100,000 lines (to avoid runaway)
+      echo "Error: did not find signing data entry, or timed out at 100,000 lines processed."
+    else
+      ((LINE_COUNT++))
+    fi
+  done
+else
+  echo "No remediation needed for BTM issues."
+fi
+
 # Base paths
 launch_agent_base_path='Library/LaunchAgents/'
 launch_daemon_base_path='Library/LaunchDaemons/'

--- a/build_assets/postinstall-suite
+++ b/build_assets/postinstall-suite
@@ -19,9 +19,9 @@ launch_agent_plist_name='com.github.macadmins.Nudge.plist'
 launch_daemon_plist_name='com.github.macadmins.Nudge.logger.plist'
 
 # In Nudge 1.1.12.81501, a duplicate label caused corruption in the BTM database.
-# Check if we are upgrading from 81501, and if so, remediate the corruption.
-if /usr/bin/grep -q -e ".*1.1.12.81501.*" /Applications/Utilities/Nudge.app/Contents/Info.plist; then
-  echo "Nudge 1.1.12.81501 is installed - proceeding with remediation."
+# Check for the touch file left by preinstall, and if present, remediate the corruption.
+if [[ -f /private/var/tmp/nudge_remediate ]]; then
+  echo "Upgrading from Nudge 1.1.12.81501 - proceeding with remediation."
 
   # Determine BTM plist path. On macOS 13.3 and lower, v4; higher and on to 14, v8.
   if [[ -f "/private/var/db/com.apple.backgroundtaskmanagement/BackgroundItems-v8.btm" ]]; then
@@ -34,25 +34,33 @@ if /usr/bin/grep -q -e ".*1.1.12.81501.*" /Applications/Utilities/Nudge.app/Cont
     echo "Error: unable to locate a BTM plist, no remediation occurred. Does this OS support BTM features?"
   fi
 
-  line_count = 0
+  line_count=0
   signing_re='.*"com.github.macadmins.Nudge".*T4SK8ZXCXG\)'
+  dne_re=", Does Not Exist"
+  signing_string='anchor apple generic and identifier \"com.github.macadmins.Nudge\" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = T4SK8ZXCXG)"'
 
   while True; do
     plist_entry=$(/usr/libexec/PlistBuddy -c "Print :\$objects:$line_count" $btm_plist_path 2>&1)
     if [[ "${plist_entry}" =~ $signing_re ]]; then
       # Remove the bad entry
-      /usr/libexec/PlistBuddy -c "Delete :\$objects:$line_count" $btm_plist
+      /usr/libexec/PlistBuddy -c "Delete :\$objects:$line_count" $btm_plist_path
       # Kickstart BTM to load in the modified DB
       /bin/launchctl kickstart -k system/com.apple.backgroundtaskmanagementd
+      echo "Remediated BTM DB and kickstarted service."
       break
 
     elif [[ ${plist_entry} =~ ", Does Not Exist" ]] || [[ $line_count -gt 100000 ]]; then
-      # Exit if we've ran through the entire plist or we hit 100,000 lines (to avoid runaway)
+      # Exit if we hit the end of the file or 100,000 lines (to avoid runaway)
       echo "Error: did not find signing data entry, or timed out at 100,000 lines processed."
+
     else
-      ((LINE_COUNT++))
+      ((line_count++))
     fi
   done
+
+  # Remove the touch file to not trigger remediation again.
+  rm /private/var/tmp/nudge_remediate
+
 else
   echo "No remediation needed for BTM issues."
 fi

--- a/build_assets/postinstall-suite
+++ b/build_assets/postinstall-suite
@@ -26,19 +26,22 @@ if [[ -f /private/var/tmp/nudge_remediate ]]; then
   # Determine BTM plist path. On macOS 13.3 and lower, v4; higher and on to 14, v8.
   if [[ -f "/private/var/db/com.apple.backgroundtaskmanagement/BackgroundItems-v8.btm" ]]; then
     btm_plist_path="/private/var/db/com.apple.backgroundtaskmanagement/BackgroundItems-v8.btm"
+    remediate=True
     echo "Set BTM plist path to v8"
   elif [[ -f "/private/var/db/com.apple.backgroundtaskmanagement/BackgroundItems-v4.btm" ]]; then
     btm_plist_path="/private/var/db/com.apple.backgroundtaskmanagement/BackgroundItems-v4.btm"
+    remediate=True
     echo "Set BTM plist path to v4"
   else
     echo "Error: unable to locate a BTM plist, no remediation occurred. Does this OS support BTM features?"
+    remediate=False
   fi
 
   line_count=0
   signing_re='.*"com.github.macadmins.Nudge".*T4SK8ZXCXG\)'
   dne_re=", Does Not Exist"
 
-  while True; do
+  while $remediate; do
     plist_entry=$(/usr/libexec/PlistBuddy -c "Print :\$objects:$line_count" $btm_plist_path 2>&1)
     plist_entry=$(iconv -f ISO-8859-1 <<< $plist_entry)
     if [[ "$plist_entry" =~ $signing_re ]]; then

--- a/build_assets/preinstall-app
+++ b/build_assets/preinstall-app
@@ -32,4 +32,12 @@ if [[ $3 == "/" ]] ; then
     # Kill Nudge is running
     /usr/bin/pgrep -i Nudge | /usr/bin/xargs kill
   fi
+
+  # In Nudge 1.1.12.81501, a duplicate label caused corruption in the BTM database.
+  # Check if we are upgrading from 81501, and if so, touch a file to trigger postinstall
+  # to remediate the corruption.
+  if /usr/bin/grep -q -e ".*1.1.12.81501.*" /Applications/Utilities/Nudge.app/Contents/Info.plist; then
+    echo "Nudge 1.1.12.81501 is installed - flagging for remediation."
+    touch /private/var/tmp/nudge_remediate
+  fi
 fi

--- a/build_nudge.zsh
+++ b/build_nudge.zsh
@@ -90,6 +90,7 @@ fi
 /usr/bin/sudo /usr/sbin/chown -R ${CONSOLEUSER}:wheel "$NUDGE_PKG_PATH"
 /bin/cp -R "${BUILDSDIR}/Release/Nudge.app" "$NUDGE_PKG_PATH/payload/Nudge.app"
 /bin/cp "${TOOLSDIR}/build_assets/preinstall-app" "$NUDGE_PKG_PATH/scripts/preinstall"
+/bin/cp "${TOOLSDIR}/build_assets/postinstall-app" "$NUDGE_PKG_PATH/scripts/postinstall"
 
 # Download specific version of munki-pkg
 echo "Downloading munki-pkg tool from github..."


### PR DESCRIPTION
Preinstall: checks if a problematic version (81501) is installed, and touches a file if so.
Postinstalls: same logic in both, looks for the touch file and if found runs the remediation.

Currently getting an "illegal byte sequence" error as I wrote this assuming /bin/sh and not ZSH - will continue working on this in Slack after dinner.

All the credit to @kevinmcox and @tuxudo for finding the BTM plist is editable and figuring out the PlistBuddy pieces.