### PR TITLE
Add Support for Screenshot Alt Text for Accessibility

### DIFF
--- a/Example Assets/com.github.macadmins.Nudge.json
+++ b/Example Assets/com.github.macadmins.Nudge.json
@@ -73,6 +73,7 @@
         "iconLightPath": "/somewhere/logoLight.png",
         "screenShotDarkPath": "/somewhere/screenShotDark.png",
         "screenShotLightPath": "/somewhere/screenShotLight.png",
+        "screenShotAltText": "Click to zoom into screenshot",
         "showDeferralCount": true,
         "simpleMode": false,
         "singleQuitButton": false,

--- a/Example Assets/com.github.macadmins.Nudge.json
+++ b/Example Assets/com.github.macadmins.Nudge.json
@@ -73,7 +73,6 @@
         "iconLightPath": "/somewhere/logoLight.png",
         "screenShotDarkPath": "/somewhere/screenShotDark.png",
         "screenShotLightPath": "/somewhere/screenShotLight.png",
-        "screenShotAltText": "Click to zoom into screenshot",
         "showDeferralCount": true,
         "simpleMode": false,
         "singleQuitButton": false,
@@ -93,7 +92,8 @@
                 "oneHourDeferralButtonText": "One Hour",
                 "primaryQuitButtonText": "Later",
                 "secondaryQuitButtonText": "I understand",
-                "subHeader": "A friendly reminder from your local IT team"
+                "subHeader": "A friendly reminder from your local IT team",
+                "screenShotAltText": "Click to zoom into screenshot"
             },
             {
                 "_language": "es",
@@ -106,7 +106,8 @@
                 "mainHeader": "Tu dispositivo requiere una actualización de seguridad",
                 "primaryQuitButtonText": "Más tarde",
                 "secondaryQuitButtonText": "Entiendo",
-                "subHeader": "Un recordatorio amistoso de su equipo de IT local"
+                "subHeader": "Un recordatorio amistoso de su equipo de IT local",
+                "screenShotAltText": "Haga clic para ampliar la captura de pantalla"
             },
             {
                 "_language": "fr",
@@ -119,7 +120,8 @@
                 "mainHeader": "Votre appareil nécessite une mise à jour de sécurité.",
                 "primaryQuitButtonText": "Plus tard",
                 "secondaryQuitButtonText": "Je comprends",
-                "subHeader": "Un rappel amical de votre équipe informatique locale"
+                "subHeader": "Un rappel amical de votre équipe informatique locale",
+                "screenShotAltText": "Cliquez pour agrandir la capture d'écran"
             },
             {
                 "_language": "de",
@@ -132,7 +134,8 @@
                 "mainHeader": "Ihr Gerät benötigt ein Sicherheitsupdate",
                 "primaryQuitButtonText": "Später",
                 "secondaryQuitButtonText": "Ich verstehe",
-                "subHeader": "Eine freundliche Erinnerung von Ihrem IT-Team"
+                "subHeader": "Eine freundliche Erinnerung von Ihrem IT-Team",
+                "screenShotAltText": "Hier klicken, um den Screenshot zu vergrößern"
             }
         ]
     }

--- a/Example Assets/com.github.macadmins.Nudge.mobileconfig
+++ b/Example Assets/com.github.macadmins.Nudge.mobileconfig
@@ -155,6 +155,8 @@
                     <string>/somewhere/screenShotDark.png</string>
                     <key>screenShotLightPath</key>
                     <string>/somewhere/screenShotLight.png</string>
+                    <key>screenShotAltText</key>
+                    <string>Click to zoom into screenshot</string>
                     <key>showDeferralCount</key>
                     <true/>
                     <key>simpleMode</key>

--- a/Example Assets/com.github.macadmins.Nudge.mobileconfig
+++ b/Example Assets/com.github.macadmins.Nudge.mobileconfig
@@ -155,8 +155,6 @@
                     <string>/somewhere/screenShotDark.png</string>
                     <key>screenShotLightPath</key>
                     <string>/somewhere/screenShotLight.png</string>
-                    <key>screenShotAltText</key>
-                    <string>Click to zoom into screenshot</string>
                     <key>showDeferralCount</key>
                     <true/>
                     <key>simpleMode</key>
@@ -200,6 +198,8 @@
                             <string>I understand</string>
                             <key>subHeader</key>
                             <string>A friendly reminder from your local IT team</string>
+                            <key>screenShotAltText</key>
+                            <string>Click to zoom into screenshot</string>
                         </dict>
                         <dict>
                             <key>_language</key>
@@ -228,6 +228,8 @@
                             <string>Entiendo</string>
                             <key>subHeader</key>
                             <string>Un recordatorio amistoso de su equipo de IT local</string>
+                            <key>screenShotAltText</key>
+                            <string>Haga clic para ampliar la captura de pantalla</string>
                         </dict>
                         <dict>
                             <key>_language</key>
@@ -256,6 +258,8 @@
                             <string>Je comprends</string>
                             <key>subHeader</key>
                             <string>Un rappel amical de votre équipe informatique locale</string>
+                            <key>screenShotAltText</key>
+                            <string>Cliquez pour agrandir la capture d'écran</string>
                         </dict>
                         <dict>
                             <key>_language</key>
@@ -283,6 +287,8 @@
                             <string>Ich verstehe</string>
                             <key>subHeader</key>
                             <string>Eine freundliche Erinnerung von Ihrem IT-Team</string>
+                            <key>screenShotAltText</key>
+                            <string>Hier klicken, um den Screenshot zu vergrößern</string>
                         </dict>
                     </array>
                 </dict>

--- a/Example Assets/com.github.macadmins.Nudge.tester.json
+++ b/Example Assets/com.github.macadmins.Nudge.tester.json
@@ -53,7 +53,8 @@
                 "oneHourDeferralButtonText": "oneHourDeferralButtonText",
                 "primaryQuitButtonText": "primaryQuitButtonText",
                 "secondaryQuitButtonText": "secondaryQuitButtonText",
-                "subHeader": "subHeader"
+                "subHeader": "subHeader",
+                "screenShotAltText": "Click to zoom into screenshot"
             }
         ]
     }

--- a/Nudge/Preferences/DefaultPreferencesNudge.swift
+++ b/Nudge/Preferences/DefaultPreferencesNudge.swift
@@ -109,6 +109,7 @@ let customDeferralDropdownText = userInterfaceUpdateElementsProfile?["customDefe
 let customDeferralButtonText = userInterfaceUpdateElementsProfile?["customDeferralButtonText"] as? String ?? userInterfaceUpdateElementsJSON?.customDeferralButtonText ?? "Custom"
 let oneDayDeferralButtonText = userInterfaceUpdateElementsProfile?["oneDayDeferralButtonText"] as? String ?? userInterfaceUpdateElementsJSON?.oneDayDeferralButtonText ?? "One Day"
 let oneHourDeferralButtonText = userInterfaceUpdateElementsProfile?["oneHourDeferralButtonText"] as? String ?? userInterfaceUpdateElementsJSON?.oneHourDeferralButtonText ?? "One Hour"
+let screenShotAltText = userInterfaceUpdateElementsProfile?["screenShotAltText"] as? String ?? userInterfaceUpdateElementsJSON?.screenShotAltText ?? "Click to zoom into screenshot"
 
 // Other important defaults
 #if DEBUG

--- a/Nudge/Preferences/PreferencesStructure.swift
+++ b/Nudge/Preferences/PreferencesStructure.swift
@@ -356,7 +356,7 @@ extension UserExperience {
 struct UserInterface: Codable {
     var actionButtonPath, fallbackLanguage: String?
     var forceFallbackLanguage, forceScreenShotIcon: Bool?
-    var iconDarkPath, iconLightPath, screenShotDarkPath, screenShotLightPath, screenShotAltText: String?
+    var iconDarkPath, iconLightPath, screenShotDarkPath, screenShotLightPath: String?
     var showDeferralCount, simpleMode, singleQuitButton: Bool?
     var updateElements: [UpdateElement]?
 }
@@ -387,7 +387,6 @@ extension UserInterface {
         iconLightPath: String?? = nil,
         screenShotDarkPath: String?? = nil,
         screenShotLightPath: String?? = nil,
-        screenShotAltText: String?? = nil,
         showDeferralCount: Bool?? = nil,
         simpleMode: Bool?? = nil,
         singleQuitButton: Bool?? = nil,
@@ -402,7 +401,6 @@ extension UserInterface {
             iconLightPath: iconLightPath ?? self.iconLightPath,
             screenShotDarkPath: screenShotDarkPath ?? self.screenShotDarkPath,
             screenShotLightPath: screenShotLightPath ?? self.screenShotLightPath,
-            screenShotAltText: screenShotAltText ?? self.screenShotAltText,
             showDeferralCount: showDeferralCount ?? self.showDeferralCount,
             simpleMode: simpleMode ?? self.simpleMode,
             singleQuitButton: singleQuitButton ?? self.simpleMode,
@@ -463,7 +461,8 @@ extension UpdateElement {
         oneHourDeferralButtonText: String?? = nil,
         primaryQuitButtonText: String?? = nil,
         secondaryQuitButtonText: String?? = nil,
-        subHeader: String?? = nil
+        subHeader: String?? = nil,
+        screenShotAltText: String?? = nil
     ) -> UpdateElement {
         return UpdateElement(
             language: language ?? self.language,
@@ -480,7 +479,8 @@ extension UpdateElement {
             oneHourDeferralButtonText: oneHourDeferralButtonText ?? self.oneHourDeferralButtonText,
             primaryQuitButtonText: primaryQuitButtonText ?? self.primaryQuitButtonText,
             secondaryQuitButtonText: secondaryQuitButtonText ?? self.secondaryQuitButtonText,
-            subHeader: subHeader ?? self.subHeader
+            subHeader: subHeader ?? self.subHeader,
+            screenShotAltText: screenShotAltText ?? self.screenShotAltText
         )
     }
     

--- a/Nudge/Preferences/PreferencesStructure.swift
+++ b/Nudge/Preferences/PreferencesStructure.swift
@@ -356,7 +356,7 @@ extension UserExperience {
 struct UserInterface: Codable {
     var actionButtonPath, fallbackLanguage: String?
     var forceFallbackLanguage, forceScreenShotIcon: Bool?
-    var iconDarkPath, iconLightPath, screenShotDarkPath, screenShotLightPath: String?
+    var iconDarkPath, iconLightPath, screenShotDarkPath, screenShotLightPath, screenShotAltText: String?
     var showDeferralCount, simpleMode, singleQuitButton: Bool?
     var updateElements: [UpdateElement]?
 }
@@ -390,7 +390,8 @@ extension UserInterface {
         showDeferralCount: Bool?? = nil,
         simpleMode: Bool?? = nil,
         singleQuitButton: Bool?? = nil,
-        updateElements: [UpdateElement]?? = nil
+        updateElements: [UpdateElement]?? = nil,
+        screenShotAltText: String?? = nil
     ) -> UserInterface {
         return UserInterface(
             actionButtonPath: actionButtonPath ?? self.actionButtonPath,
@@ -404,7 +405,8 @@ extension UserInterface {
             showDeferralCount: showDeferralCount ?? self.showDeferralCount,
             simpleMode: simpleMode ?? self.simpleMode,
             singleQuitButton: singleQuitButton ?? self.simpleMode,
-            updateElements: updateElements ?? self.updateElements
+            updateElements: updateElements ?? self.updateElements,
+            screenShotAltText: screenShotAltText ?? self.screenShotAltText
         )
     }
     
@@ -421,11 +423,11 @@ extension UserInterface {
 struct UpdateElement: Codable {
     var language, actionButtonText, customDeferralButtonText, customDeferralDropdownText, informationButtonText: String?
     var mainContentHeader, mainContentNote, mainContentSubHeader, mainContentText, mainHeader: String?
-    var oneDayDeferralButtonText, oneHourDeferralButtonText, primaryQuitButtonText, secondaryQuitButtonText, subHeader: String?
+    var oneDayDeferralButtonText, oneHourDeferralButtonText, primaryQuitButtonText, secondaryQuitButtonText, subHeader, screenShotAltText: String?
     
     enum CodingKeys: String, CodingKey {
         case language = "_language"
-        case actionButtonText, customDeferralButtonText, customDeferralDropdownText, informationButtonText, mainContentHeader, mainContentNote, mainContentSubHeader, mainContentText, mainHeader, oneDayDeferralButtonText, oneHourDeferralButtonText, primaryQuitButtonText, secondaryQuitButtonText, subHeader
+        case actionButtonText, customDeferralButtonText, customDeferralDropdownText, informationButtonText, mainContentHeader, mainContentNote, mainContentSubHeader, mainContentText, mainHeader, oneDayDeferralButtonText, oneHourDeferralButtonText, primaryQuitButtonText, secondaryQuitButtonText, subHeader, screenShotAltText
     }
 }
 
@@ -461,7 +463,8 @@ extension UpdateElement {
         oneHourDeferralButtonText: String?? = nil,
         primaryQuitButtonText: String?? = nil,
         secondaryQuitButtonText: String?? = nil,
-        subHeader: String?? = nil
+        subHeader: String?? = nil,
+        screenShotAltText: String?? = nil
     ) -> UpdateElement {
         return UpdateElement(
             language: language ?? self.language,
@@ -478,7 +481,8 @@ extension UpdateElement {
             oneHourDeferralButtonText: oneHourDeferralButtonText ?? self.oneHourDeferralButtonText,
             primaryQuitButtonText: primaryQuitButtonText ?? self.primaryQuitButtonText,
             secondaryQuitButtonText: secondaryQuitButtonText ?? self.secondaryQuitButtonText,
-            subHeader: subHeader ?? self.subHeader
+            subHeader: subHeader ?? self.subHeader,
+            screenShotAltText: screenShotAltText ?? self.screenShotAltText
         )
     }
     

--- a/Nudge/Preferences/PreferencesStructure.swift
+++ b/Nudge/Preferences/PreferencesStructure.swift
@@ -387,11 +387,11 @@ extension UserInterface {
         iconLightPath: String?? = nil,
         screenShotDarkPath: String?? = nil,
         screenShotLightPath: String?? = nil,
+        screenShotAltText: String?? = nil,
         showDeferralCount: Bool?? = nil,
         simpleMode: Bool?? = nil,
         singleQuitButton: Bool?? = nil,
-        updateElements: [UpdateElement]?? = nil,
-        screenShotAltText: String?? = nil
+        updateElements: [UpdateElement]?? = nil
     ) -> UserInterface {
         return UserInterface(
             actionButtonPath: actionButtonPath ?? self.actionButtonPath,
@@ -402,11 +402,11 @@ extension UserInterface {
             iconLightPath: iconLightPath ?? self.iconLightPath,
             screenShotDarkPath: screenShotDarkPath ?? self.screenShotDarkPath,
             screenShotLightPath: screenShotLightPath ?? self.screenShotLightPath,
+            screenShotAltText: screenShotAltText ?? self.screenShotAltText,
             showDeferralCount: showDeferralCount ?? self.showDeferralCount,
             simpleMode: simpleMode ?? self.simpleMode,
             singleQuitButton: singleQuitButton ?? self.simpleMode,
-            updateElements: updateElements ?? self.updateElements,
-            screenShotAltText: screenShotAltText ?? self.screenShotAltText
+            updateElements: updateElements ?? self.updateElements
         )
     }
     
@@ -463,8 +463,7 @@ extension UpdateElement {
         oneHourDeferralButtonText: String?? = nil,
         primaryQuitButtonText: String?? = nil,
         secondaryQuitButtonText: String?? = nil,
-        subHeader: String?? = nil,
-        screenShotAltText: String?? = nil
+        subHeader: String?? = nil
     ) -> UpdateElement {
         return UpdateElement(
             language: language ?? self.language,
@@ -481,8 +480,7 @@ extension UpdateElement {
             oneHourDeferralButtonText: oneHourDeferralButtonText ?? self.oneHourDeferralButtonText,
             primaryQuitButtonText: primaryQuitButtonText ?? self.primaryQuitButtonText,
             secondaryQuitButtonText: secondaryQuitButtonText ?? self.secondaryQuitButtonText,
-            subHeader: subHeader ?? self.subHeader,
-            screenShotAltText: screenShotAltText ?? self.screenShotAltText
+            subHeader: subHeader ?? self.subHeader
         )
     }
     

--- a/Nudge/UI/StandardMode/RightSide.swift
+++ b/Nudge/UI/StandardMode/RightSide.swift
@@ -134,7 +134,7 @@ struct StandardModeRightSide: View {
                                             .frame(maxHeight: screenshotMaxHeight)
                                     }
                                     .buttonStyle(.plain)
-                                    .help("Click to zoom into screenshot".localized(desiredLanguage: getDesiredLanguage(locale: appState.locale)))
+                                    .help(screenShotAltText.localized(desiredLanguage: getDesiredLanguage(locale: appState.locale)))
                                     .sheet(isPresented: $appState.screenShotZoomViewIsPresented) {
                                         ScreenShotZoom()
                                     }

--- a/Nudge/UI/StandardMode/RightSide.swift
+++ b/Nudge/UI/StandardMode/RightSide.swift
@@ -108,7 +108,7 @@ struct StandardModeRightSide: View {
                                 .frame(width: logoWidth, height: logoHeight)
                         }
                         .buttonStyle(.plain)
-                        .help("Click to zoom into screenshot".localized(desiredLanguage: getDesiredLanguage(locale: appState.locale)))
+                        .help(screenShotAltText.localized(desiredLanguage: getDesiredLanguage(locale: appState.locale)))
                         .sheet(isPresented: $appState.screenShotZoomViewIsPresented) {
                             ScreenShotZoom()
                         }


### PR DESCRIPTION
### Summary
This pull request introduces the ability to specify alternative text for screenshots within the `UserInterface` configuration. The alternative text (alt text) is a crucial accessibility feature that allows screen readers to describe images to users who may have visual impairments.

### Background
Screen readers are essential tools for many users, and providing alt text for images is a recommended practice to ensure that all users have a similar experience. Without alt text, the content and function of an image can be completely lost to users relying on screen readers, which is not aligned with our commitment to accessibility.

### Changes
- **PreferencesStructure.switch / UpdateElement Struct**: Included `screenShotAltText` in the `with` function for constructing new `UpdateElement` instances.
- **DefaultPreferencesNudge.swift**: Updated to handle `screenShotAltText`, falling back to a descriptive default if none is provided.
- **RightSide.swift**: Updated .help() to use `screenShotAltText` instead of static string.

### Implementation
The `screenShotAltText` can be set in the JSON / Configuration Profile configurations used to define the user interface elements. If not set, the system will use a sensible default that describes the action ("Click to zoom into the screenshot"), ensuring that the functionality remains accessible and localization is not affected.

### Testing
- Manual testing with VoiceOver confirmed that the alt text is read correctly when focus is on the screenshot.

### Impact
This change does not affect existing functionality for users who do not utilize screen readers. It strictly enhances the experience for users who rely on accessibility features.