### PR TITLE
Change Schema placeholder

### DIFF
--- a/Schema/jamf/com.github.macadmins.Nudge.json
+++ b/Schema/jamf/com.github.macadmins.Nudge.json
@@ -298,7 +298,7 @@
                                                             "type": "string",
                                                             "options": {
                                                                 "inputAttributes": {
-                                                                    "placeholder": "en"
+                                                                    "placeholder": "EX: en"
                                                                 }
                                                             }
                                                         }
@@ -881,7 +881,7 @@
                                     "type": "string",
                                     "options": {
                                         "inputAttributes": {
-                                            "placeholder": "en"
+                                            "placeholder": "EX: en"
                                         }
                                     }
                                 }
@@ -1056,7 +1056,7 @@
                                                         "type": "string",
                                                         "options": {
                                                             "inputAttributes": {
-                                                                "placeholder": "en"
+                                                                "placeholder": "EX: en"
                                                             }
                                                         }
                                                     }


### PR DESCRIPTION
Change Schema Placeholder for Language entries from `en` to `EX: en` to prevent confusion when configuring a language to override the default text.

This question comes up a lot on the Nudge slack channel.