### PR TITLE
correct aboutUpdateURLs to unsupportedURLs

### DIFF
--- a/Schema/jamf/com.github.macadmins.Nudge.json
+++ b/Schema/jamf/com.github.macadmins.Nudge.json
@@ -658,7 +658,7 @@
                             },
                             "unsupportedURLs": {
                                 "description": "The unsupportedURL - per country localization.",
-                                "title": "aboutUpdateURLs",
+                                "title": "unsupportedURLs",
                                 "anyOf": [
                                     {
                                         "title": "Not Configured",


### PR DESCRIPTION
This is a minor issue that put me in a loop for a little bit while configuring a new config profile in Jamf. Easy enough to change in my own schema, but wanted to submit it here for correction for others. This will now properly display as "unsupportedURLs" in Jamf, rather than a secondary aboutUpdateURLs.

Current: aboutUpdateURLs
Expected: unsupportedURLs