### PR TITLE
v2.0.4 release

### DIFF
--- a/.github/workflows/build_nudge_pr.yml
+++ b/.github/workflows/build_nudge_pr.yml
@@ -31,7 +31,7 @@ jobs:
         p12-file-base64: ${{ secrets.PKG_CERTIFICATES_P12_MAOS }}
         p12-password: ${{ secrets.PKG_CERTIFICATES_P12_PASSWORD_MAOS }}
 
-    - name: Run build package script
+    - name: Run build script
       run: ./build_nudge.zsh
 
     - name: get environment variables
@@ -40,7 +40,7 @@ jobs:
          echo "NUDGE_VERSION=$(/bin/cat ./build_info.txt)" >> $GITHUB_ENV
          echo "NUDGE_MAIN_VERSION=$(/bin/cat ./build_info_main.txt)" >> $GITHUB_ENV
 
-    - name: Upload packages
+    - name: Upload zip archive
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: packages

--- a/.github/workflows/build_nudge_pr.yml
+++ b/.github/workflows/build_nudge_pr.yml
@@ -47,6 +47,7 @@ jobs:
         path: outputs/
 
     - name: Clean up PR safety tag
+      if: always()
       id: clean_up_pr_safety_tag
       run: |
          /usr/bin/curl --silent --fail-with-body -X DELETE -H 'Accept: application/vnd.github.v3+json' -H 'Authorization: token ${{ github.token }}' 'https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/labels/safe-to-test'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,21 @@ Requires macOS 12.0 and higher.
 
 ### Fixed
 - Logic introduced in v2.0.1 for `requiredInstallatonDate` when using the new `gracePeriodInstallDelay` was still incorrect and has been rewritten a second time.
+  - Unit tests were changed to match the fixed behavior
+  - `gracePeriodLogic` is now computed _after_ the SOFA feed assessment
+- Logic introduced in v2.0.2 accidentally forced the `randomDelay` when using the `-demo-mode` argument. This is now removed.
+- `gracePeriodsPath` objects that were 0 bytes in size were ignored. This has been modified to allow these files
+  - Ex: Ann admin simply runs `touch` on a file.
+- The JAMF JSON schema had an incorrect title value for `unsupportedURLs`
+- PRs sent to the Nudge repo will now have the tag `safe-to-test` removed after every CI/CD run, regardless of pass/fail status.
+- The PR build script has been fixed to re-upload zipped `Nudge.app` files for user testing
 
 ## [2.0.3] - 2024-07-22
 Requires macOS 12.0 and higher.
 
 ### Changed
 - The command line argument `-disable-randomDelay` is now `-disable-random-delay`
+  - Unit tests do not honor the `randomDelay` key
 
 ### Fixed
 - When a user clicked on the `updateDevice` button, the logs would incorrectly state the user was entering the "Unsupported UI" workflow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.4] - 2024-07-22
+Requires macOS 12.0 and higher.
+
+### Fixed
+- Logic introduced in v2.0.1 for `requiredInstallatonDate` when using the new `gracePeriodInstallDelay` was still incorrect and has been rewritten a second time.
+
 ## [2.0.3] - 2024-07-22
 Requires macOS 12.0 and higher.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.4] - 2024-07-22
+## [2.0.4] - 2024-07-23
 Requires macOS 12.0 and higher.
 
 ### Fixed

--- a/Example Assets/com.github.macadmins.Nudge.tester.json
+++ b/Example Assets/com.github.macadmins.Nudge.tester.json
@@ -2,20 +2,17 @@
     "optionalFeatures": {
         "customSOFAFeedURL": "https://sofafeed.macadmins.io/v1/macos_data_feed.json",
         "_customSOFAFeedURL": "https://sofafeed.macadmins.io/beta/v1/macos_data_feed.json",
-        "utilizeSOFAFeed": true,
     },
     "osVersionRequirements": [
         {
             "aboutUpdateURL": "https://apple.com",
-            "requiredMinimumOSVersion": "14.5",
-            "requiredInstallationDate": "2025-01-01T00:00:00",
+            "requiredMinimumOSVersion": "latest",
             "unsupportedURL": "https://google.com"
         }
     ],
     "userExperience": {
         "elapsedRefreshCycle": 10,
         "initialRefreshCycle": 10,
-        "loadLaunchAgent": false,
         "nudgeRefreshCycle": 5,
         "randomDelay": false
     },

--- a/Nudge.xcodeproj/project.pbxproj
+++ b/Nudge.xcodeproj/project.pbxproj
@@ -698,7 +698,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 2.0.3;
+				MARKETING_VERSION = 2.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.macadmins.Nudge;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -729,7 +729,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 2.0.3;
+				MARKETING_VERSION = 2.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.macadmins.Nudge;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Nudge.xcodeproj/xcshareddata/xcschemes/Nudge - Debug (-bundle-mode-json, -simulate-os-version, -simulate-hardware-id).xcscheme
+++ b/Nudge.xcodeproj/xcshareddata/xcschemes/Nudge - Debug (-bundle-mode-json, -simulate-os-version, -simulate-hardware-id).xcscheme
@@ -76,7 +76,7 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "-simulate-os-version &quot;14.5&quot;"
+            argument = "-simulate-os-version &quot;14.4.1&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument

--- a/Nudge.xcodeproj/xcshareddata/xcschemes/Nudge - Debug (-demo-mode).xcscheme
+++ b/Nudge.xcodeproj/xcshareddata/xcschemes/Nudge - Debug (-demo-mode).xcscheme
@@ -72,7 +72,7 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "-demo-mode-json"
+            argument = "-demo-mode"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Nudge/Info.plist
+++ b/Nudge/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.3</string>
+	<string>2.0.4</string>
 	<key>CFBundleVersion</key>
-	<string>2.0.3</string>
+	<string>2.0.4</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Nudge/UI/Defaults.swift
+++ b/Nudge/UI/Defaults.swift
@@ -97,7 +97,6 @@ class AppState: ObservableObject {
     @Published var deferViewIsPresented = false
     @Published var additionalInfoViewIsPresented = false
     @Published var differentiateWithoutColor = NSWorkspace.shared.accessibilityDisplayShouldDifferentiateWithoutColor
-    @Published var hasUpdatedDueToDracePeriodInstallDelay = false
 }
 
 class DNDConfig {

--- a/Nudge/UI/Main.swift
+++ b/Nudge/UI/Main.swift
@@ -173,7 +173,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func sofaPreLaunchLogic() {
-        // TODO: Add more logging to "unsupported devices" UI.
         if OptionalFeatureVariables.utilizeSOFAFeed {
             var selectedOS: OSInformation?
             var foundMatch = false
@@ -353,7 +352,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func applyRandomDelayIfNecessary() {
-        if UserExperienceVariables.randomDelay && !(CommandLineUtilities().disableRandomDelayArgumentPassed() || CommandLineUtilities().unitTestingEnabled()) {
+        if UserExperienceVariables.randomDelay && !(CommandLineUtilities().disableRandomDelayArgumentPassed() || CommandLineUtilities().unitTestingEnabled() || CommandLineUtilities().demoModeEnabled()) {
             let delaySeconds = Int.random(in: 1...UserExperienceVariables.maxRandomDelayInSeconds)
             LogManager.notice("Delaying initial run (in seconds) by: \(delaySeconds)", logger: uiLog)
 

--- a/Nudge/UI/Main.swift
+++ b/Nudge/UI/Main.swift
@@ -237,11 +237,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     releaseDate = selectedOS!.releaseDate ?? Date()
                     if requiredInstallationDate == Date(timeIntervalSince1970: 0) {
                         requiredInstallationDate = selectedOS!.releaseDate?.addingTimeInterval(slaExtension) ?? DateManager().getCurrentDate().addingTimeInterval(TimeInterval(90 * 86400))
-                        LogManager.notice("Extending requiredInstallationDate to \(requiredInstallationDate)", logger: sofaLog)
-                    }
-                    if nudgePrimaryState.hasUpdatedDueToDracePeriodInstallDelay {
-                        requiredInstallationDate = requiredInstallationDate.addingTimeInterval(slaExtension)
-                        LogManager.notice("Extending requiredInstallationDate to \(requiredInstallationDate)", logger: sofaLog)
+                        LogManager.notice("Setting requiredInstallationDate via SOFA to \(requiredInstallationDate)", logger: sofaLog)
                     }
                     LogManager.notice("SOFA Matched OS Version: \(selectedOS!.productVersion)", logger: sofaLog)
                     LogManager.notice("SOFA Assets: \(selectedOS!.supportedDevices)", logger: sofaLog)
@@ -287,8 +283,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         checkForBadProfilePath()
         handleCommandLineArguments()
         applyRandomDelayIfNecessary()
-        applyGracePeriodLogic()
         sofaPreLaunchLogic()
+        applyGracePeriodLogic()
         applydelayNudgeEventLogic()
         updateNudgeState()
         handleSoftwareUpdateRequirements()

--- a/NudgeTests/NudgeTests.swift
+++ b/NudgeTests/NudgeTests.swift
@@ -73,7 +73,7 @@ class NudgeTests: XCTestCase {
         XCTAssertEqual(
             coerceStringToDate(dateString: "2022-02-01T00:00:00Z"),
             AppStateManager().gracePeriodLogic(
-                currentDate: coerceStringToDate(dateString: "2022-01-01T00:30:00Z"),
+                currentDate: coerceStringToDate(dateString: "2022-01-15T00:00:00Z"),
                 testFileDate: coerceStringToDate(dateString: "2022-01-01T00:00:00Z")
             )
         )

--- a/Schema/jamf/com.github.macadmins.Nudge.json
+++ b/Schema/jamf/com.github.macadmins.Nudge.json
@@ -912,7 +912,7 @@
                                     "type": "integer",
                                     "options": {
                                         "inputAttributes": {
-                                            "placeholder": "24"
+                                            "placeholder": "23"
                                         }
                                     }
                                 }


### PR DESCRIPTION
## [2.0.4] - 2024-07-23
Requires macOS 12.0 and higher.

### Fixed
- Logic introduced in v2.0.1 for `requiredInstallatonDate` when using the new `gracePeriodInstallDelay` was still incorrect and has been rewritten a second time.
  - Unit tests were changed to match the fixed behavior
  - `gracePeriodLogic` is now computed _after_ the SOFA feed assessment
- Logic introduced in v2.0.2 accidentally forced the `randomDelay` when using the `-demo-mode` argument. This is now removed.
- `gracePeriodsPath` objects that were 0 bytes in size were ignored. This has been modified to allow these files
  - Ex: Ann admin simply runs `touch` on a file.
- The JAMF JSON schema had an incorrect title value for `unsupportedURLs`
- PRs sent to the Nudge repo will now have the tag `safe-to-test` removed after every CI/CD run, regardless of pass/fail status.
- The PR build script has been fixed to re-upload zipped `Nudge.app` files for user testing