### PR TITLE
v2.0.5

### DIFF
--- a/.github/workflows/build_nudge_pr.yml
+++ b/.github/workflows/build_nudge_pr.yml
@@ -11,20 +11,20 @@ jobs:
 
     steps:
     - name: Checkout nudge repo
-      uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
 
     - name: Install Apple Xcode certificates
-      uses: apple-actions/import-codesign-certs@8f3fb608891dd2244cdab3d69cd68c0d37a7fe93 # v2.0.0
+      uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3.0.0
       with:
         keychain-password: ${{ github.run_id }}
         p12-file-base64: ${{ secrets.APP_CERTIFICATES_P12_MAOS }}
         p12-password: ${{ secrets.APP_CERTIFICATES_P12_PASSWORD_MAOS }}
 
     - name: Install Apple Installer certificates
-      uses: apple-actions/import-codesign-certs@8f3fb608891dd2244cdab3d69cd68c0d37a7fe93 # v2.0.0
+      uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3.0.0
       with:
         create-keychain: false # do not create a new keychain for this value
         keychain-password: ${{ github.run_id }}
@@ -41,7 +41,7 @@ jobs:
          echo "NUDGE_MAIN_VERSION=$(/bin/cat ./build_info_main.txt)" >> $GITHUB_ENV
 
     - name: Upload zip archive
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
       with:
         name: packages
         path: outputs/

--- a/.github/workflows/build_nudge_prerelease.yml
+++ b/.github/workflows/build_nudge_prerelease.yml
@@ -19,19 +19,19 @@ jobs:
 
     steps:
     - name: Checkout nudge repo
-      uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         fetch-depth: 0
 
     - name: Install Apple Xcode certificates
-      uses: apple-actions/import-codesign-certs@8f3fb608891dd2244cdab3d69cd68c0d37a7fe93 # v2.0.0
+      uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3.0.0
       with:
         keychain-password: ${{ github.run_id }}
         p12-file-base64: ${{ secrets.APP_CERTIFICATES_P12_MAOS }}
         p12-password: ${{ secrets.APP_CERTIFICATES_P12_PASSWORD_MAOS }}
 
     - name: Install Apple Installer certificates
-      uses: apple-actions/import-codesign-certs@8f3fb608891dd2244cdab3d69cd68c0d37a7fe93 # v2.0.0
+      uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3.0.0
       with:
         create-keychain: false # do not create a new keychain for this value
         keychain-password: ${{ github.run_id }}
@@ -89,7 +89,7 @@ jobs:
         files: ${{github.workspace}}/outputs/*.pkg
 
     - name: Upload packages
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
       with:
         name: packages
         path: outputs/

--- a/.github/workflows/build_nudge_prerelease_manual.yml
+++ b/.github/workflows/build_nudge_prerelease_manual.yml
@@ -11,19 +11,19 @@ jobs:
 
     steps:
     - name: Checkout nudge repo
-      uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         fetch-depth: 0
 
     - name: Install Apple Xcode certificates
-      uses: apple-actions/import-codesign-certs@8f3fb608891dd2244cdab3d69cd68c0d37a7fe93 # v2.0.0
+      uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3.0.0
       with:
         keychain-password: ${{ github.run_id }}
         p12-file-base64: ${{ secrets.APP_CERTIFICATES_P12_MAOS }}
         p12-password: ${{ secrets.APP_CERTIFICATES_P12_PASSWORD_MAOS }}
 
     - name: Install Apple Installer certificates
-      uses: apple-actions/import-codesign-certs@8f3fb608891dd2244cdab3d69cd68c0d37a7fe93 # v2.0.0
+      uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3.0.0
       with:
         create-keychain: false # do not create a new keychain for this value
         keychain-password: ${{ github.run_id }}
@@ -81,7 +81,7 @@ jobs:
         files: ${{github.workspace}}/outputs/*.pkg
 
     - name: Upload packages
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
       with:
         name: packages
         path: outputs/

--- a/.github/workflows/build_nudge_release.yml
+++ b/.github/workflows/build_nudge_release.yml
@@ -19,19 +19,19 @@ jobs:
 
     steps:
     - name: Checkout nudge repo
-      uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         fetch-depth: 0
 
     - name: Install Apple Xcode certificates
-      uses: apple-actions/import-codesign-certs@8f3fb608891dd2244cdab3d69cd68c0d37a7fe93 # v2.0.0
+      uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3.0.0
       with:
         keychain-password: ${{ github.run_id }}
         p12-file-base64: ${{ secrets.APP_CERTIFICATES_P12_MAOS }}
         p12-password: ${{ secrets.APP_CERTIFICATES_P12_PASSWORD_MAOS }}
 
     - name: Install Apple Installer certificates
-      uses: apple-actions/import-codesign-certs@8f3fb608891dd2244cdab3d69cd68c0d37a7fe93 # v2.0.0
+      uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3.0.0
       with:
         create-keychain: false # do not create a new keychain for this value
         keychain-password: ${{ github.run_id }}
@@ -89,7 +89,7 @@ jobs:
         files: ${{github.workspace}}/outputs/*.pkg
 
     - name: Upload packages
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
       with:
         name: packages
         path: outputs/

--- a/.github/workflows/build_nudge_release_manual.yml
+++ b/.github/workflows/build_nudge_release_manual.yml
@@ -11,19 +11,19 @@ jobs:
 
     steps:
     - name: Checkout nudge repo
-      uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         fetch-depth: 0
 
     - name: Install Apple Xcode certificates
-      uses: apple-actions/import-codesign-certs@8f3fb608891dd2244cdab3d69cd68c0d37a7fe93 # v2.0.0
+      uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3.0.0
       with:
         keychain-password: ${{ github.run_id }}
         p12-file-base64: ${{ secrets.APP_CERTIFICATES_P12_MAOS }}
         p12-password: ${{ secrets.APP_CERTIFICATES_P12_PASSWORD_MAOS }}
 
     - name: Install Apple Installer certificates
-      uses: apple-actions/import-codesign-certs@8f3fb608891dd2244cdab3d69cd68c0d37a7fe93 # v2.0.0
+      uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3.0.0
       with:
         create-keychain: false # do not create a new keychain for this value
         keychain-password: ${{ github.run_id }}
@@ -81,7 +81,7 @@ jobs:
         files: ${{github.workspace}}/outputs/*.pkg
 
     - name: Upload packages
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
       with:
         name: packages
         path: outputs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Requires macOS 12.0 and higher.
   - **WARNNG BREAKING CHANGE** - This changes the SLA computation and will result in a different `requiredInstallationDate` than offered in Nudge v2.0 -> v2.01.
   - Ex: Device is on 14.3 and needing to go to 14.5.
     - While 14.4.1 -> 14.5 are not under active exploit, 14.4 contains fixes for 14.3 that were under active exploit.
+  - Addresses [610](https://github.com/macadmins/nudge/issues/610) and [613](https://github.com/macadmins/nudge/issues/613)
 
 ## [2.0.4] - 2024-07-23
 Requires macOS 12.0 and higher.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.0.5] - 2024-07-24
 Requires macOS 12.0 and higher.
 
+### Added
+- To artificially change the `requredInstallationDate` to honor a previous macOS minor version, set `minorVersionRecalculationThreshold` under `osVersionRequirement` in amount of minor versions.
+  - Ex: `minorVersionRecalculationThreshold` is set to 1 and SOFA feed has macOS 14.5 available
+    - macOS device is 14.3: Target macOS 14.4.1 requiredInstallationDate of 2024-04-15 00:00:00 +0000
+    - macOS device is 14.4: Target macOS 14.4.1 requiredInstallationDate of 2024-04-15 00:00:00 +0000
+    - macOS device is 14.4.1: Target macOS 14.5 requiredInstallationDate of 2024-06-03 00:00:00 +0000
+  - Addresses [612](https://github.com/macadmins/nudge/issues/612)
+
 ### Changed
 - The `Actively Exploited` logic internally within Nudge and the UI on the left sidebar will show `True` if any previous updates missing on the device had active exploits.
   - **WARNNG BREAKING CHANGE** - This changes the SLA computation and will result in a different `requiredInstallationDate` than offered in Nudge v2.0 -> v2.01.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,21 @@ Requires macOS 12.0 and higher.
 ### Added
 - To artificially change the `requredInstallationDate` to honor a previous macOS minor version, set `minorVersionRecalculationThreshold` under `osVersionRequirement` in amount of minor versions.
   - Ex: `minorVersionRecalculationThreshold` is set to 1 and SOFA feed has macOS 14.5 available
-    - macOS device is 14.3: Target macOS 14.4.1 requiredInstallationDate of 2024-04-15 00:00:00 +0000
-    - macOS device is 14.4: Target macOS 14.4.1 requiredInstallationDate of 2024-04-15 00:00:00 +0000
-    - macOS device is 14.4.1: Target macOS 14.5 requiredInstallationDate of 2024-06-03 00:00:00 +0000
+    - macOS device is 14.0: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-08 00:00:00 +0000
+    - macOS device is 14.1: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-08 00:00:00 +0000
+    - macOS device is 14.2: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-08 00:00:00 +0000
+    - macOS device is 14.3: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-08 00:00:00 +0000
+    - macOS device is 14.4: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-15 00:00:00 +0000
+\   - macOS device is 14.4.1: Required OS: 14.5 - Target macOS 14.5 requiredInstallationDate of 2024-06-03 00:00:00 +0000
+    - macOS device is 14.5: Required OS: 14.5 - Fully updated
+  - Ex: `minorVersionRecalculationThreshold` is set to 2 and SOFA feed has macOS 14.5 available
+    - macOS device is 14.0: Required OS: 14.5 - Target macOS 14.4 requiredInstallationDate of 2024-03-21 00:00:00 +0000
+    - macOS device is 14.1: Required OS: 14.5 - Target macOS 14.4 requiredInstallationDate of 2024-03-21 00:00:00 +0000
+    - macOS device is 14.2: Required OS: 14.5 - Target macOS 14.4 requiredInstallationDate of 2024-03-21 00:00:00 +0000
+    - macOS device is 14.3: Required OS: 14.5 - Target macOS 14.4 requiredInstallationDate of 2024-03-21 00:00:00 +0000
+    - macOS device is 14.4: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-15 00:00:00 +0000
+\   - macOS device is 14.4.1: Required OS: 14.5 - Target macOS 14.5 requiredInstallationDate of 2024-06-03 00:00:00 +0000
+    - macOS device is 14.5: Required OS: 14.5 - Fully updated
   - Addresses [612](https://github.com/macadmins/nudge/issues/612)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Requires macOS 12.0 and higher.
     - macOS device is 14.1: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-08 00:00:00 +0000
     - macOS device is 14.2: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-08 00:00:00 +0000
     - macOS device is 14.3: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-08 00:00:00 +0000
-    - macOS device is 14.4: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-15 00:00:00 +0000
+    - macOS device is 14.4: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-15 00:00:00 +0000 (Note, this time is different than the others as there is no active exploiteds)
     - macOS device is 14.4.1: Required OS: 14.5 - Target macOS 14.5 requiredInstallationDate of 2024-06-03 00:00:00 +0000
     - macOS device is 14.5: Required OS: 14.5 - Fully updated
   - Ex: `minorVersionRecalculationThreshold` is set to 2 and SOFA feed has macOS 14.5 available

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Requires macOS 12.0 and higher.
     - macOS device is 14.2: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-08 00:00:00 +0000
     - macOS device is 14.3: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-08 00:00:00 +0000
     - macOS device is 14.4: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-15 00:00:00 +0000
-\   - macOS device is 14.4.1: Required OS: 14.5 - Target macOS 14.5 requiredInstallationDate of 2024-06-03 00:00:00 +0000
+    - macOS device is 14.4.1: Required OS: 14.5 - Target macOS 14.5 requiredInstallationDate of 2024-06-03 00:00:00 +0000
     - macOS device is 14.5: Required OS: 14.5 - Fully updated
   - Ex: `minorVersionRecalculationThreshold` is set to 2 and SOFA feed has macOS 14.5 available
     - macOS device is 14.0: Required OS: 14.5 - Target macOS 14.4 requiredInstallationDate of 2024-03-21 00:00:00 +0000
@@ -23,7 +23,7 @@ Requires macOS 12.0 and higher.
     - macOS device is 14.2: Required OS: 14.5 - Target macOS 14.4 requiredInstallationDate of 2024-03-21 00:00:00 +0000
     - macOS device is 14.3: Required OS: 14.5 - Target macOS 14.4 requiredInstallationDate of 2024-03-21 00:00:00 +0000
     - macOS device is 14.4: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-15 00:00:00 +0000
-\   - macOS device is 14.4.1: Required OS: 14.5 - Target macOS 14.5 requiredInstallationDate of 2024-06-03 00:00:00 +0000
+    - macOS device is 14.4.1: Required OS: 14.5 - Target macOS 14.5 requiredInstallationDate of 2024-06-03 00:00:00 +0000
     - macOS device is 14.5: Required OS: 14.5 - Fully updated
   - Addresses [612](https://github.com/macadmins/nudge/issues/612)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,16 +14,17 @@ Requires macOS 12.0 and higher.
     - macOS device is 14.1: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-08 00:00:00 +0000
     - macOS device is 14.2: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-08 00:00:00 +0000
     - macOS device is 14.3: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-08 00:00:00 +0000
-    - macOS device is 14.4: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-15 00:00:00 +0000 (Note, this time is different than the others as there is no active exploiteds)
-    - macOS device is 14.4.1: Required OS: 14.5 - Target macOS 14.5 requiredInstallationDate of 2024-06-03 00:00:00 +0000
+    - macOS device is 14.4: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-08 00:00:00 +0000
+    - macOS device is 14.4.1: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-15 00:00:00 +0000
+      - This device's requiredInstallationDate is different than the others as there is no active exploit on 14.4.1
     - macOS device is 14.5: Required OS: 14.5 - Fully updated
   - Ex: `minorVersionRecalculationThreshold` is set to 2 and SOFA feed has macOS 14.5 available
     - macOS device is 14.0: Required OS: 14.5 - Target macOS 14.4 requiredInstallationDate of 2024-03-21 00:00:00 +0000
     - macOS device is 14.1: Required OS: 14.5 - Target macOS 14.4 requiredInstallationDate of 2024-03-21 00:00:00 +0000
     - macOS device is 14.2: Required OS: 14.5 - Target macOS 14.4 requiredInstallationDate of 2024-03-21 00:00:00 +0000
     - macOS device is 14.3: Required OS: 14.5 - Target macOS 14.4 requiredInstallationDate of 2024-03-21 00:00:00 +0000
-    - macOS device is 14.4: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-15 00:00:00 +0000
-    - macOS device is 14.4.1: Required OS: 14.5 - Target macOS 14.5 requiredInstallationDate of 2024-06-03 00:00:00 +0000
+    - macOS device is 14.4: Required OS: 14.5 - Target macOS 14.4 requiredInstallationDate of 2024-03-21 00:00:00 +0000
+    - macOS device is 14.4.1: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-15 00:00:00 +0000
     - macOS device is 14.5: Required OS: 14.5 - Fully updated
   - Addresses [612](https://github.com/macadmins/nudge/issues/612)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Requires macOS 12.0 and higher.
 - When `showRequiredDate` is set to `True` and the admin is using the default values for `requiredInstallationDisplayFormat`, Nudge will attempt to understand the current locale and display the menu item appropriately.
   - Addresses [615](https://github.com/macadmins/nudge/issues/615)
 
+### Fixed
+- Several components in the Github Actions were triggering deprecation warnings. These have been addressed by updating to the latest version of these components
+  - Addresses [616](https://github.com/macadmins/nudge/issues/616)
+
 ## [2.0.4] - 2024-07-23
 Requires macOS 12.0 and higher.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Requires macOS 12.0 and higher.
   - Ex: Device is on 14.3 and needing to go to 14.5.
     - While 14.4.1 -> 14.5 are not under active exploit, 14.4 contains fixes for 14.3 that were under active exploit.
   - Addresses [610](https://github.com/macadmins/nudge/issues/610) and [613](https://github.com/macadmins/nudge/issues/613)
+- When `showRequiredDate` is set to `True` and the admin is using the default values for `requiredInstallationDisplayFormat`, Nudge will attempt to understand the current locale and display the menu item appropriately.
+  - Addresses [615](https://github.com/macadmins/nudge/issues/615)
 
 ## [2.0.4] - 2024-07-23
 Requires macOS 12.0 and higher.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.5] - 2024-07-24
+Requires macOS 12.0 and higher.
+
+### Changed
+- The `Actively Exploited` logic internally within Nudge and the UI on the left sidebar will show `True` if any previous updates missing on the device had active exploits.
+  - **WARNNG BREAKING CHANGE** - This changes the SLA computation and will result in a different `requiredInstallationDate` than offered in Nudge v2.0 -> v2.01.
+  - Ex: Device is on 14.3 and needing to go to 14.5.
+    - While 14.4.1 -> 14.5 are not under active exploit, 14.4 contains fixes for 14.3 that were under active exploit.
+
 ## [2.0.4] - 2024-07-23
 Requires macOS 12.0 and higher.
 

--- a/Nudge.xcodeproj/project.pbxproj
+++ b/Nudge.xcodeproj/project.pbxproj
@@ -698,7 +698,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 2.0.4;
+				MARKETING_VERSION = 2.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.macadmins.Nudge;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -729,7 +729,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 2.0.4;
+				MARKETING_VERSION = 2.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.macadmins.Nudge;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Nudge/Info.plist
+++ b/Nudge/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.4</string>
+	<string>2.0.5</string>
 	<key>CFBundleVersion</key>
-	<string>2.0.4</string>
+	<string>2.0.5</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Nudge/Preferences/DefaultPreferencesNudge.swift
+++ b/Nudge/Preferences/DefaultPreferencesNudge.swift
@@ -233,6 +233,12 @@ struct OSVersionRequirementVariables {
         ""
     }
 
+    static var minorVersionRecalculationThreshold: Int {
+        osVersionRequirementsProfile?.minorVersionRecalculationThreshold ??
+        osVersionRequirementsJSON?.minorVersionRecalculationThreshold ??
+        0
+    }
+
     static var nonActivelyExploitedCVEsMajorUpgradeSLA: Int {
         osVersionRequirementsProfile?.nonActivelyExploitedCVEsMajorUpgradeSLA ??
         osVersionRequirementsJSON?.nonActivelyExploitedCVEsMajorUpgradeSLA ??

--- a/Nudge/Preferences/PreferencesStructure.swift
+++ b/Nudge/Preferences/PreferencesStructure.swift
@@ -151,6 +151,7 @@ struct OSVersionRequirement: Codable {
     var activelyExploitedCVEsMajorUpgradeSLA: Int?
     var activelyExploitedCVEsMinorUpdateSLA: Int?
     var majorUpgradeAppPath: String?
+    var minorVersionRecalculationThreshold: Int?
     var nonActivelyExploitedCVEsMajorUpgradeSLA: Int?
     var nonActivelyExploitedCVEsMinorUpdateSLA: Int?
     var requiredInstallationDate: Date?
@@ -170,6 +171,7 @@ extension OSVersionRequirement {
         self.activelyExploitedCVEsMajorUpgradeSLA = fromDictionary["activelyExploitedCVEsMajorUpgradeSLA"] as? Int
         self.activelyExploitedCVEsMinorUpdateSLA = fromDictionary["activelyExploitedCVEsMinorUpdateSLA"] as? Int
         self.majorUpgradeAppPath = fromDictionary["majorUpgradeAppPath"] as? String
+        self.minorVersionRecalculationThreshold = fromDictionary["minorVersionRecalculationThreshold"] as? Int
         self.nonActivelyExploitedCVEsMajorUpgradeSLA = fromDictionary["nonActivelyExploitedCVEsMajorUpgradeSLA"] as? Int
         self.nonActivelyExploitedCVEsMinorUpdateSLA = fromDictionary["nonActivelyExploitedCVEsMinorUpdateSLA"] as? Int
         self.requiredMinimumOSVersion = fromDictionary["requiredMinimumOSVersion"] as? String
@@ -248,6 +250,7 @@ extension OSVersionRequirement {
         activelyExploitedCVEsMajorUpgradeSLA: Int? = nil,
         activelyExploitedCVEsMinorUpdateSLA: Int? = nil,
         majorUpgradeAppPath: String? = nil,
+        minorVersionRecalculationThreshold: Int? = nil,
         nonActivelyExploitedCVEsMajorUpgradeSLA: Int? = nil,
         nonActivelyExploitedCVEsMinorUpdateSLA: Int? = nil,
         requiredInstallationDate: Date? = nil,
@@ -265,6 +268,7 @@ extension OSVersionRequirement {
             activelyExploitedCVEsMajorUpgradeSLA: activelyExploitedCVEsMajorUpgradeSLA ?? self.activelyExploitedCVEsMajorUpgradeSLA,
             activelyExploitedCVEsMinorUpdateSLA: activelyExploitedCVEsMinorUpdateSLA ?? self.activelyExploitedCVEsMinorUpdateSLA,
             majorUpgradeAppPath: majorUpgradeAppPath ?? self.majorUpgradeAppPath,
+            minorVersionRecalculationThreshold: minorVersionRecalculationThreshold ?? self.minorVersionRecalculationThreshold,
             nonActivelyExploitedCVEsMajorUpgradeSLA: nonActivelyExploitedCVEsMajorUpgradeSLA ?? self.nonActivelyExploitedCVEsMajorUpgradeSLA,
             nonActivelyExploitedCVEsMinorUpdateSLA: nonActivelyExploitedCVEsMinorUpdateSLA ?? self.nonActivelyExploitedCVEsMinorUpdateSLA,
             requiredInstallationDate: requiredInstallationDate ?? self.requiredInstallationDate,

--- a/Nudge/UI/Main.swift
+++ b/Nudge/UI/Main.swift
@@ -293,9 +293,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                                 }
                             }
                             if !foundVersion {
-                                requiredInstallationDate = selectedOS!.releaseDate?.addingTimeInterval(slaExtension) ?? DateManager().getCurrentDate().addingTimeInterval(TimeInterval(90 * 86400))
                                 LogManager.warning("Could not find requiredInstallationDate from target macOS \(targetVersion)", logger: sofaLog)
-                                LogManager.notice("Setting requiredInstallationDate via SOFA to \(requiredInstallationDate)", logger: sofaLog)
+                                requiredInstallationDate = selectedOS!.releaseDate?.addingTimeInterval(slaExtension) ?? DateManager().getCurrentDate().addingTimeInterval(TimeInterval(90 * 86400))
                             }
                         } else {
                             requiredInstallationDate = selectedOS!.releaseDate?.addingTimeInterval(slaExtension) ?? DateManager().getCurrentDate().addingTimeInterval(TimeInterval(90 * 86400))

--- a/Nudge/UI/Main.swift
+++ b/Nudge/UI/Main.swift
@@ -226,7 +226,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
                     // Filter versions between current and selected OS version
                     let filteredVersions = VersionManager().removeDuplicates(from: allVersions.filter {
-                        VersionManager.versionGreaterThan(currentVersion: $0, newVersion: currentInstalledVersion) &&
+                        VersionManager.versionGreaterThanOrEqual(currentVersion: $0, newVersion: currentInstalledVersion) &&
                         VersionManager.versionLessThanOrEqual(currentVersion: $0, newVersion: selectedOSVersion)
                     })
 
@@ -236,6 +236,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     })
 
                     // Count actively exploited CVEs in the filtered versions
+                    LogManager.notice("Assessing macOS version range for active exploits: \(filteredVersions) ", logger: sofaLog)
                     for osVersion in macOSSOFAAssets {
                         if filteredVersions.contains(osVersion.latest.productVersion) {
                             totalActivelyExploitedCVEs += osVersion.latest.activelyExploitedCVEs.count

--- a/Nudge/UI/Main.swift
+++ b/Nudge/UI/Main.swift
@@ -286,11 +286,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                                 let safeIndex = max(0, minorVersions.count - (OSVersionRequirementVariables.minorVersionRecalculationThreshold + 1)) // Ensure the index is within bounds
                                 let targetVersion = minorVersions[safeIndex]
                                 var foundVersion = false
-                                LogManager.notice("minorVersionRecalculationThreshold is set - Targeting macOS \(targetVersion) requiredInstallationDate via SOFA", logger: sofaLog)
+                                LogManager.notice("minorVersionRecalculationThreshold is set to \(OSVersionRequirementVariables.minorVersionRecalculationThreshold) - Current Version: \(currentInstalledVersion) - Targeting version \(targetVersion) requiredInstallationDate via SOFA", logger: sofaLog)
                                 for osVersion in macOSSOFAAssets {
                                     for securityRelease in osVersion.securityReleases.reversed() {
                                         if VersionManager.versionGreaterThanOrEqual(currentVersion: securityRelease.productVersion, newVersion: targetVersion) && VersionManager.versionLessThan(currentVersion: currentInstalledVersion, newVersion: targetVersion) {
                                             requiredInstallationDate = securityRelease.releaseDate?.addingTimeInterval(slaExtension) ?? DateManager().getCurrentDate().addingTimeInterval(TimeInterval(90 * 86400))
+                                            LogManager.notice("Found target macOS version \(targetVersion) - releaseDate is \(securityRelease.releaseDate!), slaExtension is \(LoggerUtilities().printTimeInterval(slaExtension))", logger: sofaLog)
                                             foundVersion = true
                                             break
                                         }

--- a/Nudge/UI/Main.swift
+++ b/Nudge/UI/Main.swift
@@ -289,7 +289,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                                 LogManager.notice("minorVersionRecalculationThreshold is set to \(OSVersionRequirementVariables.minorVersionRecalculationThreshold) - Current Version: \(currentInstalledVersion) - Targeting version \(targetVersion) requiredInstallationDate via SOFA", logger: sofaLog)
                                 for osVersion in macOSSOFAAssets {
                                     for securityRelease in osVersion.securityReleases.reversed() {
-                                        if VersionManager.versionGreaterThanOrEqual(currentVersion: securityRelease.productVersion, newVersion: targetVersion) && VersionManager.versionLessThan(currentVersion: currentInstalledVersion, newVersion: targetVersion) {
+                                        if VersionManager.versionGreaterThanOrEqual(currentVersion: securityRelease.productVersion, newVersion: targetVersion) && VersionManager.versionLessThanOrEqual(currentVersion: currentInstalledVersion, newVersion: targetVersion) {
                                             requiredInstallationDate = securityRelease.releaseDate?.addingTimeInterval(slaExtension) ?? DateManager().getCurrentDate().addingTimeInterval(TimeInterval(90 * 86400))
                                             LogManager.notice("Found target macOS version \(targetVersion) - releaseDate is \(securityRelease.releaseDate!), slaExtension is \(LoggerUtilities().printTimeInterval(slaExtension))", logger: sofaLog)
                                             foundVersion = true

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -1492,6 +1492,10 @@ struct VersionManager {
         return majorVersion
     }
 
+    static func getMajorVersion(from version: String) -> Int {
+        return Int(version.split(separator: ".").first.map(String.init)!)!
+    }
+
     static func getMinorOSVersion() -> Int {
         var minorOSVersion = ProcessInfo().operatingSystemVersion.minorVersion
 //        if (CommandLineUtilities().simulateOSVersion() != nil) {
@@ -1514,6 +1518,12 @@ struct VersionManager {
 
     static func newNudgeEvent() -> Bool {
         versionGreaterThan(currentVersion: nudgePrimaryState.requiredMinimumOSVersion, newVersion: nudgePrimaryState.userRequiredMinimumOSVersion)
+    }
+
+    // Helper function to remove duplicates while preserving order
+    func removeDuplicates(from array: [String]) -> [String] {
+        var seen = Set<String>()
+        return array.filter { seen.insert($0).inserted }
     }
 
     // Adapted from https://stackoverflow.com/a/25453654

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -894,6 +894,15 @@ struct LoggerUtilities {
         return PrefsWrapper.requiredMinimumOSVersion == "0.0"
     }
 
+    func printTimeInterval(_ interval: TimeInterval) -> String {
+        let days = Int(interval) / (24 * 3600)
+        let hours = (Int(interval) % (24 * 3600)) / 3600
+        let minutes = (Int(interval) % 3600) / 60
+        let seconds = Int(interval) % 60
+
+        return "\(days) days, \(hours) hours, \(minutes) minutes, \(seconds) seconds"
+    }
+
     private func updateDeferralCount(_ count: inout Int, resetCount: Bool, key: String) {
         if CommandLineUtilities().demoModeEnabled() {
             count = 0

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -553,10 +553,20 @@ struct DateManager {
         return formatter
     }()
 
-    func coerceDateToString(date: Date, formatterString: String) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = formatterString
-        return formatter.string(from: date)
+    func coerceDateToString(date: Date, formatterString: String, locale: Locale? = nil) -> String {
+        if formatterString == "MM/dd/yyyy" {
+            // Use the specified locale or the current locale if none is provided
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateStyle = .short
+            dateFormatter.timeStyle = .none
+            dateFormatter.locale = locale ?? Locale.current
+            return dateFormatter.string(from: date)
+        } else {
+            let formatter = DateFormatter()
+            formatter.dateFormat = formatterString
+            formatter.locale = locale ?? Locale.current
+            return formatter.string(from: date)
+        }
     }
 
     func coerceStringToDate(dateString: String) -> Date {

--- a/Schema/jamf/com.github.macadmins.Nudge.json
+++ b/Schema/jamf/com.github.macadmins.Nudge.json
@@ -508,6 +508,25 @@
                                     }
                                 ]
                             },
+                            "minorVersionRecalculationThreshold": {
+                                "description": "The amount of minor versions a device can be behind before the requiredInstallationDate is recalculated against a previous update. (Note: This key is only used with Nudge v2.0.5 and higher)",
+                                "anyOf": [
+                                    {
+                                        "title": "Not Configured",
+                                        "type": "null"
+                                    },
+                                    {
+                                        "title": "Configured",
+                                        "default": 0,
+                                        "type": "integer",
+                                        "options": {
+                                            "inputAttributes": {
+                                                "placeholder": "0"
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
                             "nonActivelyExploitedCVEsMajorUpgradeSLA": {
                                 "description": "When a major upgrade is not under active exploit but contains CVEs, this is the amount of days a user has to install the update. (Note: This key is only used with Nudge v2.0 and higher)",
                                 "anyOf": [


### PR DESCRIPTION
### Added
- To artificially change the `requredInstallationDate` to honor a previous macOS minor version, set `minorVersionRecalculationThreshold` under `osVersionRequirement` in amount of minor versions.
  - Ex: `minorVersionRecalculationThreshold` is set to 1 and SOFA feed has macOS 14.5 available
    - macOS device is 14.0: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-08 00:00:00 +0000
    - macOS device is 14.1: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-08 00:00:00 +0000
    - macOS device is 14.2: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-08 00:00:00 +0000
    - macOS device is 14.3: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-08 00:00:00 +0000
    - macOS device is 14.4: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-08 00:00:00 +0000
    - macOS device is 14.4.1: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-15 00:00:00 +0000
      - This device's requiredInstallationDate is different than the others as there is no active exploit on 14.4.1
    - macOS device is 14.5: Required OS: 14.5 - Fully updated
  - Ex: `minorVersionRecalculationThreshold` is set to 2 and SOFA feed has macOS 14.5 available
    - macOS device is 14.0: Required OS: 14.5 - Target macOS 14.4 requiredInstallationDate of 2024-03-21 00:00:00 +0000
    - macOS device is 14.1: Required OS: 14.5 - Target macOS 14.4 requiredInstallationDate of 2024-03-21 00:00:00 +0000
    - macOS device is 14.2: Required OS: 14.5 - Target macOS 14.4 requiredInstallationDate of 2024-03-21 00:00:00 +0000
    - macOS device is 14.3: Required OS: 14.5 - Target macOS 14.4 requiredInstallationDate of 2024-03-21 00:00:00 +0000
    - macOS device is 14.4: Required OS: 14.5 - Target macOS 14.4 requiredInstallationDate of 2024-03-21 00:00:00 +0000
    - macOS device is 14.4.1: Required OS: 14.5 - Target macOS 14.4.1 requiredInstallationDate of 2024-04-15 00:00:00 +0000
    - macOS device is 14.5: Required OS: 14.5 - Fully updated
  - Addresses [612](https://github.com/macadmins/nudge/issues/612)

### Changed
- The `Actively Exploited` logic internally within Nudge and the UI on the left sidebar will show `True` if any previous updates missing on the device had active exploits.
  - **WARNNG BREAKING CHANGE** - This changes the SLA computation and will result in a different `requiredInstallationDate` than offered in Nudge v2.0 -> v2.01.
  - Ex: Device is on 14.3 and needing to go to 14.5.
    - While 14.4.1 -> 14.5 are not under active exploit, 14.4 contains fixes for 14.3 that were under active exploit.
  - Addresses [610](https://github.com/macadmins/nudge/issues/610) and [613](https://github.com/macadmins/nudge/issues/613)
- When `showRequiredDate` is set to `True` and the admin is using the default values for `requiredInstallationDisplayFormat`, Nudge will attempt to understand the current locale and display the menu item appropriately.
  - Addresses [615](https://github.com/macadmins/nudge/issues/615)

### Fixed
- Several components in the Github Actions were triggering deprecation warnings. These have been addressed by updating to the latest version of these components
  - Addresses [616](https://github.com/macadmins/nudge/issues/616)