### PR TITLE
v2.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,15 @@ Requires macOS 12.0 and higher.
 ### Added
 
 ### Changed
+- The `board-id` property has been moved to a `debug` log event
+  - Works around reports like [623](https://github.com/macadmins/nudge/issues/623)
 
 ### Fixed
 - The `unsupportedURL` key was not being honored when clicking on the Unsupported UI button
   - Addresses [626](https://github.com/macadmins/nudge/issues/626)
+- Intel Virtual Machines now have a forced `board-id` property that complies with Apple's own logic/SOFA.
+  - Thanks to [Mykola Grymalyuk](https://github.com/khronokernel) for the [PR](https://github.com/macadmins/nudge/pull/622)
+  - Addresses [621](https://github.com/macadmins/nudge/issues/621)
 
 ## [2.0.5] - 2024-07-24
 Requires macOS 12.0 and higher.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Requires macOS 12.0 and higher.
 - Intel Virtual Machines now have a forced `board-id` property that complies with Apple's own logic/SOFA.
   - Thanks to [Mykola Grymalyuk](https://github.com/khronokernel) for the [PR](https://github.com/macadmins/nudge/pull/622)
   - Addresses [621](https://github.com/macadmins/nudge/issues/621)
+- `requiredInstallationDisplayFormat` was no longer being honored on Nudge versions 2.0.1 through 2.0.5 due to a regression
+  - Addresses [627](https://github.com/macadmins/nudge/issues/627)
 
 ## [2.0.5] - 2024-07-24
 Requires macOS 12.0 and higher.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,8 @@ Requires macOS 12.0 and higher.
 
 ### Changed
 - Now built on Swift 5.10, Xcode 15.4 and macOS 14
+- macOS 12.3 and higher uses new logic for "delta major upgrades"
+  - Admins are no longer required to use supplemental keys and hacks to get Nudge to open and enforce major upgrades
 - New Xcode Scheme `-bundle-mode-profile` to test profile logic
   - `-bundle-mode` has been renamed to `-bundle-mode-json`
 - You can now pass two formats of **strings** to `requiredInstallationDate`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Requires macOS 12.0 and higher.
 
 ### Added
+- Device within the `nudgeMinorUpdateEventLaunchDelay` now show current and delayed date
+  - These logs also now show in the default Nudge logs when use the `logger` LaunchDaemon
+  - Addresses [625](https://github.com/macadmins/nudge/issues/625)
 
 ### Changed
+- Some logs have been changed from `info` to `error`, `warning` or `notice` to give admins more visibility into Nudge behaviors
 - The `board-id` property has been moved to a `debug` log event
   - Works around reports like [623](https://github.com/macadmins/nudge/issues/623)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.6] - 2024-08-01
+Requires macOS 12.0 and higher.
+
+### Added
+
+### Changed
+
+### Fixed
+- The `unsupportedURL` key was not being honored when clicking on the Unsupported UI button
+  - Addresses [626](https://github.com/macadmins/nudge/issues/626)
+
 ## [2.0.5] - 2024-07-24
 Requires macOS 12.0 and higher.
 

--- a/Nudge.xcodeproj/project.pbxproj
+++ b/Nudge.xcodeproj/project.pbxproj
@@ -698,7 +698,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 2.0.5;
+				MARKETING_VERSION = 2.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.macadmins.Nudge;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -729,7 +729,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 2.0.5;
+				MARKETING_VERSION = 2.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.macadmins.Nudge;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Nudge.xcodeproj/xcshareddata/xcschemes/Nudge - Debug (-bundle-mode-json, -simulate-os-version, -simulate-hardware-id).xcscheme
+++ b/Nudge.xcodeproj/xcshareddata/xcschemes/Nudge - Debug (-bundle-mode-json, -simulate-os-version, -simulate-hardware-id).xcscheme
@@ -76,7 +76,7 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "-simulate-os-version &quot;14.4.1&quot;"
+            argument = "-simulate-os-version &quot;14.5&quot;"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument

--- a/Nudge/Info.plist
+++ b/Nudge/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.5</string>
+	<string>2.0.6</string>
 	<key>CFBundleVersion</key>
-	<string>2.0.5</string>
+	<string>2.0.6</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Nudge/UI/Common/InformationButton.swift
+++ b/Nudge/UI/Common/InformationButton.swift
@@ -44,7 +44,7 @@ struct InformationButtonAsAction: View {
     
     var body: some View {
         Button(action: {
-            UIUtilities().openMoreInfo()
+            UIUtilities().openMoreInfoUnsupported()
             UIUtilities().postUpdateDeviceActions(userClicked: true, unSupportedUI: true)
         }) {
             Text(.init(UserInterfaceVariables.actionButtonTextUnsupported.localized(desiredLanguage: getDesiredLanguage(locale: appState.locale))))

--- a/Nudge/UI/Main.swift
+++ b/Nudge/UI/Main.swift
@@ -387,11 +387,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     center.add(request)
                     LogManager.info("Scheduled notification for terminated application \(applicationIdentifier)", logger: uiLog)
                 case .denied:
-                    LogManager.info("Notifications are denied; cannot schedule notification for \(applicationIdentifier)", logger: uiLog)
+                    LogManager.error("Notifications are denied; cannot schedule notification for \(applicationIdentifier)", logger: uiLog)
                 case .notDetermined:
-                    LogManager.info("Notification status not determined; cannot schedule notification for \(applicationIdentifier)", logger: uiLog)
+                    LogManager.warning("Notification status not determined; cannot schedule notification for \(applicationIdentifier)", logger: uiLog)
                 @unknown default:
-                    LogManager.info("Unknown notification status; cannot schedule notification for \(applicationIdentifier)", logger: uiLog)
+                    LogManager.warning("Unknown notification status; cannot schedule notification for \(applicationIdentifier)", logger: uiLog)
             }
         }
     }
@@ -783,7 +783,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             LogManager.error("Failed to terminate application: \(application.bundleIdentifier ?? "")", logger: utilsLog)
             return
         }
-        LogManager.info("Successfully terminated application: \(application.bundleIdentifier ?? "")", logger: utilsLog)
+        LogManager.notice("Successfully terminated application: \(application.bundleIdentifier ?? "")", logger: utilsLog)
     }
 
     private func terminateApplications(afterInitialLaunch: Bool = false) {

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -561,7 +561,7 @@ struct DateManager {
 
     func coerceDateToString(date: Date, formatterString: String, locale: Locale? = nil) -> String {
         if formatterString == "MM/dd/yyyy" {
-            // Use the specified locale or the current locale if none is provided
+            // If using default, try to use the locale's values
             let dateFormatter = DateFormatter()
             dateFormatter.dateStyle = .short
             dateFormatter.timeStyle = .none
@@ -570,7 +570,7 @@ struct DateManager {
         } else {
             let formatter = DateFormatter()
             formatter.dateFormat = formatterString
-            formatter.locale = locale ?? Locale.current
+            print(formatter.string(from: date))
             return formatter.string(from: date)
         }
     }

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -711,11 +711,8 @@ struct DeviceManager {
         getSysctlValue(for: "hw.model") ?? ""
     }
     
-    func getVirtualMachineStatus() -> Bool {
-        if getSysctlValue(for: "kern.hv_vmm_present") == "1" {
-            return true
-        }
-        return false
+    func isVirtualMachine() -> Bool {
+        getSysctlValue(for: "kern.hv_vmm_present") == "1"
     }
 
     func getHardwareModelIDs() -> [String] {
@@ -724,7 +721,7 @@ struct DeviceManager {
         let hardwareModelID = getIORegInfo(serviceTarget: "target-sub-type") ?? "Unknown"
         let gestaltModelStringID = getKeyResultFromGestalt("HWModelStr")
         
-        if getVirtualMachineStatus() && getCPUTypeString() == "Intel" {
+        if isVirtualMachine() && getCPUTypeString() == "Intel" {
             boardID = "VMM-x86_64"
         }
 

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -710,12 +710,23 @@ struct DeviceManager {
     func getHardwareModel() -> String {
         getSysctlValue(for: "hw.model") ?? ""
     }
+    
+    func getVirtualMachineStatus() -> Bool {
+        if getSysctlValue(for: "kern.hv_vmm_present") == "1" {
+            return true
+        }
+        return false
+    }
 
     func getHardwareModelIDs() -> [String] {
-        let boardID = getIORegInfo(serviceTarget: "board-id") ?? "Unknown"
+        var boardID = getIORegInfo(serviceTarget: "board-id") ?? "Unknown"
         let bridgeID = getBridgeModelID()
         let hardwareModelID = getIORegInfo(serviceTarget: "target-sub-type") ?? "Unknown"
         let gestaltModelStringID = getKeyResultFromGestalt("HWModelStr")
+        
+        if getVirtualMachineStatus() && getCPUTypeString() == "Intel" {
+            boardID = "VMM-x86_64"
+        }
 
         LogManager.debug("Hardware Board ID: \(boardID)", logger: utilsLog)
         LogManager.debug("Hardware Bridge ID: \(bridgeID)", logger: utilsLog)

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -761,7 +761,12 @@ struct DeviceManager {
         }
 
         guard let property = IORegistryEntryCreateCFProperty(service, serviceTarget as CFString, kCFAllocatorDefault, 0)?.takeRetainedValue() else {
-            LogManager.error("Failed to fetch \(serviceTarget) property.", logger: utilsLog)
+            if serviceTarget == "board-id" {
+                // This serviceTarget fails on lots of machines, putting it as a debug
+                LogManager.debug("Failed to fetch \(serviceTarget) property.", logger: utilsLog)
+            } else {
+                LogManager.error("Failed to fetch \(serviceTarget) property.", logger: utilsLog)
+            }
             return nil
         }
 

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -214,9 +214,11 @@ struct AppStateManager {
             return PrefsWrapper.requiredInstallationDate
         }
 
-        if releaseDate.addingTimeInterval(TimeInterval(launchDelay * 86400)) > currentDate {
+        let potentialLaunchDelay = releaseDate.addingTimeInterval(TimeInterval(launchDelay * 86400))
+
+        if potentialLaunchDelay > currentDate {
             let eventType = isMajorUpgradeRequired ? "nudgeMajorUpgradeEventLaunchDelay" : "nudgeMinorUpdateEventLaunchDelay"
-            LogManager.info("Device within \(eventType)", logger: uiLog)
+            LogManager.notice("Device within \(eventType) - Current Date: \(currentDate), Respected Date: \(potentialLaunchDelay)", logger: uiLog)
             nudgePrimaryState.shouldExit = true
             return currentDate
         } else {

--- a/Nudge/Utilities/Utils.swift
+++ b/Nudge/Utilities/Utils.swift
@@ -19,9 +19,9 @@ import SystemConfiguration
 struct AppStateManager {
     func activateNudge() {
         if OptionalFeatureVariables.honorFocusModes {
-            LogManager.info("honorFocusModes is configured - checking focus status. Warning: This feature may be unstable.", logger: utilsLog)
+            LogManager.notice("honorFocusModes is configured - checking focus status. Warning: This feature may be unstable.", logger: utilsLog)
             if isFocusModeEnabled() {
-                LogManager.info("Device has focus modes set - bypassing activation event", logger: utilsLog)
+                LogManager.notice("Device has focus modes set - bypassing activation event", logger: utilsLog)
                 return
             }
         }
@@ -96,7 +96,7 @@ struct AppStateManager {
 
         // Bail Nudge if within gracePeriodLaunchDelay
         if gracePeriodLaunchDelay > gracePeriodPathCreationTimeInHours {
-            LogManager.info("gracePeriodPath (\(gracePeriodPath)) within gracePeriodLaunchDelay (\(gracePeriodLaunchDelay)) - File age is \(gracePeriodPathCreationTimeInHours) hours", logger: uiLog)
+            LogManager.notice("gracePeriodPath (\(gracePeriodPath)) within gracePeriodLaunchDelay (\(gracePeriodLaunchDelay)) - File age is \(gracePeriodPathCreationTimeInHours) hours", logger: uiLog)
             nudgePrimaryState.shouldExit = true
             return currentDate
         } else {
@@ -106,7 +106,7 @@ struct AppStateManager {
         if gracePeriodInstallDelay > gracePeriodPathCreationTimeInHours {
             if currentDate > originalRequiredInstallationDate {
                 requiredInstallationDate = currentDate.addingTimeInterval(Double(gracePeriodsDelay) * 3600)
-                LogManager.info("Device permitted for gracePeriodInstallDelay - setting date from: \(originalRequiredInstallationDate) to: \(requiredInstallationDate)", logger: uiLog)
+                LogManager.notice("Device permitted for gracePeriodInstallDelay - setting date from: \(originalRequiredInstallationDate) to: \(requiredInstallationDate)", logger: uiLog)
                 return requiredInstallationDate
             }
         } else {


### PR DESCRIPTION
## [2.0.6] - 2024-08-01
Requires macOS 12.0 and higher.

### Added
- Device within the `nudgeMinorUpdateEventLaunchDelay` now show current and delayed date
  - These logs also now show in the default Nudge logs when use the `logger` LaunchDaemon
  - Addresses [625](https://github.com/macadmins/nudge/issues/625)

### Changed
- Some logs have been changed from `info` to `error`, `warning` or `notice` to give admins more visibility into Nudge behaviors
- The `board-id` property has been moved to a `debug` log event
  - Works around reports like [623](https://github.com/macadmins/nudge/issues/623)

### Fixed
- The `unsupportedURL` key was not being honored when clicking on the Unsupported UI button
  - Addresses [626](https://github.com/macadmins/nudge/issues/626)
- Intel Virtual Machines now have a forced `board-id` property that complies with Apple's own logic/SOFA.
  - Thanks to [Mykola Grymalyuk](https://github.com/khronokernel) for the [PR](https://github.com/macadmins/nudge/pull/622)
  - Addresses [621](https://github.com/macadmins/nudge/issues/621)
- `requiredInstallationDisplayFormat` was no longer being honored on Nudge versions 2.0.1 through 2.0.5 due to a regression
  - Addresses [627](https://github.com/macadmins/nudge/issues/627)