### PR TITLE
Added logging for troubleshooting/diagnosing settings

### DIFF
--- a/Nudge/UI/Main.swift
+++ b/Nudge/UI/Main.swift
@@ -263,20 +263,28 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     nudgePrimaryState.activelyExploitedCVEs = activelyExploitedCVEs
                     switch (activelyExploitedCVEs, presentCVEs, AppStateManager().requireMajorUpgrade()) {
                     case (false, true, true):
+                        LogManager.notice("Non Actively Exploited Major Upgrade detected. Using nonActivelyExploitedCVEsMajorUpgradeSLA value: \(OSVersionRequirementVariables.nonActivelyExploitedCVEsMajorUpgradeSLA)", logger: sofaLog)
                         slaExtension = TimeInterval(OSVersionRequirementVariables.nonActivelyExploitedCVEsMajorUpgradeSLA * 86400)
                     case (false, true, false):
+                        LogManager.notice("Non Actively Exploited Minor Update detected. Using nonActivelyExploitedCVEsMinorUpdateSLA value: \(OSVersionRequirementVariables.nonActivelyExploitedCVEsMinorUpdateSLA)", logger: sofaLog)
                         slaExtension = TimeInterval(OSVersionRequirementVariables.nonActivelyExploitedCVEsMinorUpdateSLA * 86400)
                     case (true, false, true): // The selected major upgrade does not have CVEs, but the old OS does
+                        LogManager.notice("Actively Exploited Major Upgrade detected. Using activelyExploitedCVEsMajorUpgradeSLA value: \(OSVersionRequirementVariables.activelyExploitedCVEsMajorUpgradeSLA)", logger: sofaLog)
                         slaExtension = TimeInterval(OSVersionRequirementVariables.activelyExploitedCVEsMajorUpgradeSLA * 86400)
                     case (true, true, true):
+                        LogManager.notice("Actively Exploited Major Upgrade detected. Using activelyExploitedCVEsMajorUpgradeSLA value: \(OSVersionRequirementVariables.activelyExploitedCVEsMajorUpgradeSLA)", logger: sofaLog)
                         slaExtension = TimeInterval(OSVersionRequirementVariables.activelyExploitedCVEsMajorUpgradeSLA * 86400)
                     case (true, false, false):
+                        LogManager.notice("Actively Exploited Minor Update detected. Using activelyExploitedCVEsMinorUpdateSLA value: \(OSVersionRequirementVariables.activelyExploitedCVEsMinorUpdateSLA)", logger: sofaLog)
                         slaExtension = TimeInterval(OSVersionRequirementVariables.activelyExploitedCVEsMinorUpdateSLA * 86400)
                     case (true, true, false):
+                        LogManager.notice("Actively Exploited Minor Update detected. Using activelyExploitedCVEsMinorUpdateSLA value: \(OSVersionRequirementVariables.activelyExploitedCVEsMinorUpdateSLA)", logger: sofaLog)
                         slaExtension = TimeInterval(OSVersionRequirementVariables.activelyExploitedCVEsMinorUpdateSLA * 86400)
                     case (false, false, true):
+                        LogManager.notice("Standard Major Upgrade detected. Using standardMajorUpgradeSLA value: \(OSVersionRequirementVariables.standardMajorUpgradeSLA)", logger: sofaLog)
                         slaExtension = TimeInterval(OSVersionRequirementVariables.standardMajorUpgradeSLA * 86400)
                     case (false, false, false):
+                        LogManager.notice("Standard Minor Update detected. Using standardMinorUpdateSLA value: \(OSVersionRequirementVariables.standardMinorUpdateSLA)", logger: sofaLog)
                         slaExtension = TimeInterval(OSVersionRequirementVariables.standardMinorUpdateSLA * 86400)
                     default: // If we get here, something is wrong, use 90 days as a safety
                         LogManager.warning("SLA Extension logic failed, using 90 days as a safety", logger: sofaLog)


### PR DESCRIPTION
This just adds some verbosity to what SOFA case is detected and what value is being used to extend the requiredInstallationDate to easily see if the settings expected are being used instead of having to process calendar math.

Sample output shows matching values from the variables in the configuration file:
`Nudge  -simulate-os-version "14.6"`

```
[com.github.macadmins.Nudge:sofa] Assessing macOS version range for active exploits: ["14.6", "14.6.1"]
[com.github.macadmins.Nudge:sofa] Standard Minor Update detected. Using standardMinorUpdateSLA value: 61
[com.github.macadmins.Nudge:sofa] SOFA Actively Exploited CVEs: false
[com.github.macadmins.Nudge:sofa] Setting requiredInstallationDate via SOFA to 2024-10-07 00:00:00 +0000
```

`Nudge  -simulate-os-version "14.4"`

```
[com.github.macadmins.Nudge:sofa] Assessing macOS version range for active exploits: ["14.4", "14.4.1", "14.5", "14.6", "14.6.1"]
[com.github.macadmins.Nudge:sofa] Actively Exploited Minor Update detected. Using activelyExploitedCVEsMinorUpdateSLA value: 25
[com.github.macadmins.Nudge:sofa] SOFA Actively Exploited CVEs: true
[com.github.macadmins.Nudge:sofa] Setting requiredInstallationDate via SOFA to 2024-09-01 00:00:00 +0000
]
```


`Nudge  -simulate-os-version "13.5"`
```
[com.github.macadmins.Nudge:sofa] Assessing macOS version range for active exploits: ["13.5", "13.5.1", "13.5.2", "13.6", "13.6.1", "13.6.2", "13.6.3", "13.6.4", "13.6.5", "13.6.6", "13.6.7", "13.6.8", "13.6.9", "14", "14.1", "14.1.1", "14.1.2", "14.2", "14.2.1", "14.3", "14.3.1", "14.4", "14.4.1", "14.5", "14.6", "14.6.1"]
[com.github.macadmins.Nudge:sofa] Actively Exploited Major Upgrade detected. Using activelyExploitedCVEsMajorUpgradeSLA value: 26
[com.github.macadmins.Nudge:sofa] SOFA Actively Exploited CVEs: true
[com.github.macadmins.Nudge:sofa] Setting requiredInstallationDate via SOFA to 2024-09-02 00:00:00 +0000
```


Sample settings block:
```
    "osVersionRequirements": [
        {
            "requiredMinimumOSVersion": "latest-supported",
            "standardMajorUpgradeSLA": 60,
            "activelyExploitedCVEsMinorUpdateSLA": 25,
            "activelyExploitedCVEsMajorUpgradeSLA": 26,
            "nonActivelyExploitedCVEsMajorUpgradeSLA": 28,
            "nonActivelyExploitedCVEsMinorUpdateSLA": 27,
            "standardMinorUpdateSLA": 61
        }
    ],
```