### PR TITLE
Avoid showing unsupported device UI if already running required major OS

### DIFF
--- a/Nudge/UI/Main.swift
+++ b/Nudge/UI/Main.swift
@@ -342,7 +342,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                                 supportedDevice in Globals.hardwareModelIDs.contains { $0.uppercased() == supportedDevice.uppercased() } }
                             )
                             LogManager.notice("Assessed Model ID found in SOFA Entry: \(deviceMatchFound)", logger: sofaLog)
-                            nudgePrimaryState.deviceSupportedByOSVersion = deviceMatchFound
+                            let majorRequiredVersion = VersionManager.getMajorRequiredNudgeOSVersion()
+                            let currentMajorVersion = VersionManager.getMajorOSVersion()
+                            if !deviceMatchFound && (majorRequiredVersion == currentMajorVersion) {
+                                LogManager.warning("Assessed Model ID not found in SOFA Entry, but device is already running required major OS version. Disregarding unsupported UI.", logger: sofaLog)
+                                nudgePrimaryState.deviceSupportedByOSVersion = true
+                            } else {
+                                nudgePrimaryState.deviceSupportedByOSVersion = deviceMatchFound
+                            }
                         }
                     }
                     foundMatch = true


### PR DESCRIPTION
Incorrect data from SOFA or gdmf can cause Nudge to think that the required OS version is unsupported. If the device is already running the required major OS version, assume it's bad data and log a warning instead of displaying the unsupported device UI.