### PR TITLE
Fix for Issue #664

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -3324,7 +3324,7 @@
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nödvändiga Datumet:"
+            "value" : "Sista datum:"
           }
         },
         "uk" : {


### PR DESCRIPTION
Updates the Swedish translation for Required Date to a more culturally appropriate form. In this case it translates to "Deadline:".