### PR TITLE
Use multilingual as standard word rather than the neologism, 'multi-linguistic'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="/assets/NudgeIcon.png" width=10% height=10%>
 
 # Nudge (macadmin's Slack [#nudge](https://macadmins.slack.com/archives/CDUU7DJQ2))
-Nudge is a multi-linguistic application, offering custom user deferrals, which strongly encourages macOS updates. Written in Swift and SwiftUI.
+Nudge is a multilingual application, offering custom user deferrals, which strongly encourages macOS updates. Written in Swift and SwiftUI.
 
 Nudge will only work on macOS Big Sur 11 and later and is a replacement for the original Nudge, which was written in Python 2/3. If you need to enforce macOS updates for earlier versions, it is recommended to use [nudge-python](https://github.com/macadmins/nudge-python).
 


### PR DESCRIPTION
multilingual is the proper term, rather than multi-linguistic, eg https://www.l10nglobal.com/en/multilingual-subtitling